### PR TITLE
do ensure_ascii=False for webhook payloads

### DIFF
--- a/bots/webhook_utils.py
+++ b/bots/webhook_utils.py
@@ -40,7 +40,7 @@ def sign_payload(payload, secret):
     Sign a webhook payload using HMAC-SHA256. Returns a base64-encoded HMAC-SHA256 signature
     """
     # Convert the payload to a canonical JSON string
-    payload_json = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    payload_json = json.dumps(payload, sort_keys=True, ensure_ascii=False, separators=(",", ":"))
 
     # Create the signature
     signature = hmac.new(secret, payload_json.encode("utf-8"), hashlib.sha256).digest()

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -99,7 +99,7 @@ def sign_payload(payload, secret):
     Sign a webhook payload using HMAC-SHA256. Returns a base64-encoded HMAC-SHA256 signature
     """
     # Convert the payload to a canonical JSON string
-    payload_json = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    payload_json = json.dumps(payload, sort_keys=True, ensure_ascii=False, separators=(",", ":"))
 
     # Decode the secret
     secret_decoded = base64.b64decode(secret)


### PR DESCRIPTION
By default python does ensure_ascii=True when doing json.dumps. This caused complications for webhook verification when dealing with webhook payloads that had non-ascii characters. This can happen if the bot metadata contains them. 

Thanks to Yuguan Qin for voicing the issue and proposing the fix. Slack conversation here: https://attendee-community.slack.com/archives/C0811D5T79T/p1747793429177289