### PR TITLE
Add AssemblyAI word_boost and boost_param support (inspired by Deepgram/OpenAI keyword PR #260)

### DIFF
--- a/bots/models.py
+++ b/bots/models.py
@@ -266,8 +266,8 @@ class Bot(models.Model):
     def assembly_ai_language_detection(self):
         return self.settings.get("transcription_settings", {}).get("assembly_ai", {}).get("language_detection", False)
 
-    def assemblyai_word_boost(self):
-        return self.settings.get("transcription_settings", {}).get("assembly_ai", {}).get("word_boost", None)
+    def assemblyai_keyterms_prompt(self):
+        return self.settings.get("transcription_settings", {}).get("assembly_ai", {}).get("keyterms_prompt", None)
 
     def assemblyai_boost_param(self):
         return self.settings.get("transcription_settings", {}).get("assembly_ai", {}).get("boost_param", None)

--- a/bots/models.py
+++ b/bots/models.py
@@ -266,6 +266,12 @@ class Bot(models.Model):
     def assembly_ai_language_detection(self):
         return self.settings.get("transcription_settings", {}).get("assembly_ai", {}).get("language_detection", False)
 
+    def assemblyai_word_boost(self):
+        return self.settings.get("transcription_settings", {}).get("assembly_ai", {}).get("word_boost", None)
+
+    def assemblyai_boost_param(self):
+        return self.settings.get("transcription_settings", {}).get("assembly_ai", {}).get("boost_param", None)
+
     def deepgram_language(self):
         return self.settings.get("transcription_settings", {}).get("deepgram", {}).get("language", None)
 

--- a/bots/serializers.py
+++ b/bots/serializers.py
@@ -177,7 +177,7 @@ class BotImageSerializer(serializers.Serializer):
                 "properties": {
                     "language_code": {"type": "string", "description": "The language code to use for transcription. See here for available languages: https://www.assemblyai.com/docs/speech-to-text/pre-recorded-audio/supported-languages"},
                     "language_detection": {"type": "boolean", "description": "Whether to automatically detect the spoken language."},
-                    "word_boost": {
+                    "keyterms_prompt": {
                         "type": "array",
                         "items": {"type": "string"},
                         "description": "List of words or phrases to boost in the transcript. See AssemblyAI docs for details."
@@ -425,7 +425,7 @@ class CreateBotSerializer(serializers.Serializer):
                 "properties": {
                     "language_code": {"type": "string"},
                     "language_detection": {"type": "boolean"},
-                    "word_boost": {
+                    "keyterms_prompt": {
                         "type": "array",
                         "items": {"type": "string"},
                         "description": "List of words or phrases to boost in the transcript. See AssemblyAI docs for details."

--- a/bots/serializers.py
+++ b/bots/serializers.py
@@ -177,6 +177,16 @@ class BotImageSerializer(serializers.Serializer):
                 "properties": {
                     "language_code": {"type": "string", "description": "The language code to use for transcription. See here for available languages: https://www.assemblyai.com/docs/speech-to-text/pre-recorded-audio/supported-languages"},
                     "language_detection": {"type": "boolean", "description": "Whether to automatically detect the spoken language."},
+                    "word_boost": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "List of words or phrases to boost in the transcript. See AssemblyAI docs for details."
+                    },
+                    "boost_param": {
+                        "type": "string",
+                        "enum": ["low", "default", "high"],
+                        "description": "How much to boost the provided words/phrases. See AssemblyAI docs for details."
+                    },
                 },
                 "additionalProperties": False,
             },
@@ -415,6 +425,16 @@ class CreateBotSerializer(serializers.Serializer):
                 "properties": {
                     "language_code": {"type": "string"},
                     "language_detection": {"type": "boolean"},
+                    "word_boost": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "List of words or phrases to boost in the transcript. See AssemblyAI docs for details."
+                    },
+                    "boost_param": {
+                        "type": "string",
+                        "enum": ["low", "default", "high"],
+                        "description": "How much to boost the provided words/phrases. See AssemblyAI docs for details."
+                    },
                 },
                 "required": [],
                 "additionalProperties": False,

--- a/bots/tasks/process_utterance_task.py
+++ b/bots/tasks/process_utterance_task.py
@@ -323,6 +323,14 @@ def get_transcription_via_assemblyai(utterance):
     elif recording.bot.assembly_ai_language_code():
         data["language_code"] = recording.bot.assembly_ai_language_code()
 
+    # Add word_boost and boost_param if set
+    word_boost = recording.bot.assemblyai_word_boost()
+    if word_boost:
+        data["word_boost"] = word_boost
+    boost_param = recording.bot.assemblyai_boost_param()
+    if boost_param:
+        data["boost_param"] = boost_param
+
     url = f"{base_url}/transcript"
     response = requests.post(url, json=data, headers=headers)
 

--- a/bots/tasks/process_utterance_task.py
+++ b/bots/tasks/process_utterance_task.py
@@ -323,10 +323,10 @@ def get_transcription_via_assemblyai(utterance):
     elif recording.bot.assembly_ai_language_code():
         data["language_code"] = recording.bot.assembly_ai_language_code()
 
-    # Add word_boost and boost_param if set
-    word_boost = recording.bot.assemblyai_word_boost()
-    if word_boost:
-        data["word_boost"] = word_boost
+    # Add keyterms_prompt and boost_param if set
+    keyterms_prompt = recording.bot.assemblyai_keyterms_prompt()
+    if keyterms_prompt:
+        data["keyterms_prompt"] = keyterms_prompt
     boost_param = recording.bot.assemblyai_boost_param()
     if boost_param:
         data["boost_param"] = boost_param

--- a/bots/tests/test_process_utterance_task.py
+++ b/bots/tests/test_process_utterance_task.py
@@ -673,12 +673,12 @@ class AssemblyAIProviderTest(TransactionTestCase):
             # The code has max_retries = 120
             self.assertEqual(m_get.call_count, 120)
 
-    def test_word_boost_and_boost_param_included(self):
-        """Test that word_boost and boost_param are included in the AssemblyAI request if set in settings."""
+    def test_keyterms_prompt_and_boost_param_included(self):
+        """Test that keyterms_prompt and boost_param are included in the AssemblyAI request if set in settings."""
         self.bot.settings = {
             "transcription_settings": {
                 "assembly_ai": {
-                    "word_boost": ["aws", "azure", "google cloud"],
+                    "keyterms_prompt": ["aws", "azure", "google cloud"],
                     "boost_param": "high",
                 }
             }
@@ -719,12 +719,12 @@ class AssemblyAIProviderTest(TransactionTestCase):
             self.assertIsNone(failure)
             self.assertEqual(transcript["transcript"], "hello assembly")
 
-            # Check that the transcript creation request included word_boost and boost_param
+            # Check that the transcript creation request included keyterms_prompt and boost_param
             # The second call to requests.post is the transcript creation
             transcript_call = m_post.call_args_list[1]
             _, kwargs = transcript_call
             data = kwargs["json"]
-            self.assertIn("word_boost", data)
-            self.assertEqual(data["word_boost"], ["aws", "azure", "google cloud"])
+            self.assertIn("keyterms_prompt", data)
+            self.assertEqual(data["keyterms_prompt"], ["aws", "azure", "google cloud"])
             self.assertIn("boost_param", data)
             self.assertEqual(data["boost_param"], "high")

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -928,7 +928,7 @@ components:
                 language_detection:
                   type: boolean
                   description: Whether to automatically detect the spoken language.
-                word_boost:
+                keyterms_prompt:
                   type: array
                   items:
                     type: string

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -928,6 +928,18 @@ components:
                 language_detection:
                   type: boolean
                   description: Whether to automatically detect the spoken language.
+                word_boost:
+                  type: array
+                  items:
+                    type: string
+                  description: 'List of words or phrases to boost in the transcript. See https://www.assemblyai.com/docs/Transcribe%20Audio/custom-vocabulary for details.'
+                boost_param:
+                  type: string
+                  enum:
+                    - low
+                    - default
+                    - high
+                  description: 'How much to boost the provided words/phrases. See https://www.assemblyai.com/docs/Transcribe%20Audio/custom-vocabulary for details.'
               additionalProperties: false
           required: []
           description: 'The transcription settings for the bot, e.g. {''deepgram'':


### PR DESCRIPTION
**Description:**

⚠️ **Draft/Proof of Concept – No tests run, just a helpful starting point!**  

Hi team! This PR was created with the help of AI, referencing the approach and code patterns from [PR #260](https://github.com/attendee-labs/attendee/pull/260) (which added Deepgram `keywords`/`keyterms` and OpenAI `language` support).  

Also, as you can probably tell, this PR description was also written by AI. 

I wanted to extend similar functionality to AssemblyAI, specifically:

- **Adds support for `word_boost` (list of strings) and `boost_param` (low/default/high) in AssemblyAI transcription settings**
- Updates the model, serializer, OpenAPI spec, and transcription task to pass these parameters to AssemblyAI if set
- Adds a test to verify these parameters are included in the API request (but I did not run the test suite)

**What’s included:**
- `bots/models.py`: Adds `assemblyai_word_boost()` and `assemblyai_boost_param()` methods
- `bots/serializers.py`: Updates schema to allow `word_boost` and `boost_param` for AssemblyAI
- `bots/tasks/process_utterance_task.py`: Passes these params to AssemblyAI if present
- `docs/openapi.yml`: Documents the new settings
- `bots/tests/test_process_utterance_task.py`: Adds a test for the new config (not run)

**Notes:**
- I did not run the tests or the linter, and this is just a proof of concept for maintainers to review, take over, or improve as needed.
- If you want to finish this up, please run the test suite and check for any integration issues.
- I’m happy for this PR to be co-opted or replaced by a more robust implementation!

**Reference:**  
- [PR #260: Add openai language param and deepgram model, keyterms and keywords params](https://github.com/attendee-labs/attendee/pull/260)

Thanks for considering, and let me know if you have any feedback or want me to try anything else!