### PR TITLE
Add tunable OpenAI env vars

### DIFF
--- a/bots/models.py
+++ b/bots/models.py
@@ -257,7 +257,8 @@ class Bot(models.Model):
         return self.settings.get("transcription_settings", {}).get("openai", {}).get("prompt", None)
 
     def openai_transcription_model(self):
-        return self.settings.get("transcription_settings", {}).get("openai", {}).get("model", "gpt-4o-transcribe")
+        default_model = os.getenv("OPENAI_MODEL_NAME", "gpt-4o-transcribe")
+        return self.settings.get("transcription_settings", {}).get("openai", {}).get("model", default_model)
 
     def openai_transcription_language(self):
         return self.settings.get("transcription_settings", {}).get("openai", {}).get("language", None)

--- a/bots/serializers.py
+++ b/bots/serializers.py
@@ -1,5 +1,6 @@
 import base64
 import json
+import os
 from dataclasses import asdict
 
 import jsonschema
@@ -29,6 +30,17 @@ from .models import (
     RecordingViews,
     TranscriptionProviders,
 )
+
+
+def get_openai_model_enum():
+    """Get allowed OpenAI models including custom env var if set"""
+    default_models = ["gpt-4o-transcribe", "gpt-4o-mini-transcribe"]
+    custom_model = os.getenv("OPENAI_MODEL_NAME")
+    if custom_model and custom_model not in default_models:
+        return default_models + [custom_model]
+    return default_models
+
+
 from .utils import is_valid_png, meeting_type_from_url, transcription_provider_from_meeting_url_and_transcription_settings
 
 # Define the schema once
@@ -158,7 +170,7 @@ class BotImageSerializer(serializers.Serializer):
                 "properties": {
                     "model": {
                         "type": "string",
-                        "enum": ["gpt-4o-transcribe", "gpt-4o-mini-transcribe"],
+                        "enum": get_openai_model_enum(),
                         "description": "The OpenAI model to use for transcription",
                     },
                     "prompt": {
@@ -416,7 +428,7 @@ class CreateBotSerializer(serializers.Serializer):
                 "properties": {
                     "model": {
                         "type": "string",
-                        "enum": ["gpt-4o-transcribe", "gpt-4o-mini-transcribe"],
+                        "enum": get_openai_model_enum(),
                         "description": "The OpenAI model to use for transcription",
                     },
                     "prompt": {

--- a/bots/tasks/process_utterance_task.py
+++ b/bots/tasks/process_utterance_task.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import os
 import time
 
 import requests
@@ -259,7 +260,8 @@ def get_transcription_via_openai(utterance):
     payload_mp3 = pcm_to_mp3(utterance.audio_blob.tobytes(), sample_rate=utterance.sample_rate)
 
     # Prepare the request for OpenAI's transcription API
-    url = "https://api.openai.com/v1/audio/transcriptions"
+    base_url = os.getenv("OPENAI_BASE_URL", "https://api.openai.com/v1")
+    url = f"{base_url}/audio/transcriptions"
     headers = {
         "Authorization": f"Bearer {openai_credentials['api_key']}",
     }

--- a/docs/transcription.md
+++ b/docs/transcription.md
@@ -56,15 +56,6 @@ Closed caption-based transcription is free.
 
 For third-party-based transcription, you need to add your API Key for a provider like Deepgram, OpenAI, Gladia, or Assembly AI in the Settings > Credentials page.
 
-### Note on custom OpenAI proxy servers
-
-To use a custom OpenAI-compatible endpoint (such as a proxy server or alternative model provider), set these environment variables:
-
-- `OPENAI_BASE_URL`: The base URL for your custom endpoint (default: `https://api.openai.com/v1`)
-- `OPENAI_MODEL_NAME`: The model name to use for transcription (default: `gpt-4o-transcribe`)
-
-Example: `OPENAI_BASE_URL=https://your-proxy.com/v1` and `OPENAI_MODEL_NAME=whisper-large-v3`
-
 ## Transcription errors
 
 If you are using third-party-based transcription, you may encounter errors from the transcription provider. These errors are visible in the bot detail page in the dashboard, in the transcription section.
@@ -137,3 +128,12 @@ $50 in free credits for new users.
 ### OpenAI
 
 Cheaper then the other providers, but less accurate and often chooses the wrong language when the language is not specified in advance. Can transcribe audio where the speaker is switching languages in the middle of a sentence. Lacks word-level timestamps.
+
+#### Note on custom OpenAI proxy servers
+
+To use a custom OpenAI-compatible endpoint (such as a proxy server or alternative model provider), set these environment variables:
+
+- `OPENAI_BASE_URL`: The base URL for your custom endpoint (default: `https://api.openai.com/v1`)
+- `OPENAI_MODEL_NAME`: The model name to use for transcription (default: `gpt-4o-transcribe`)
+
+Example: `OPENAI_BASE_URL=https://your-proxy.com/v1` and `OPENAI_MODEL_NAME=whisper-large-v3`

--- a/docs/transcription.md
+++ b/docs/transcription.md
@@ -56,6 +56,15 @@ Closed caption-based transcription is free.
 
 For third-party-based transcription, you need to add your API Key for a provider like Deepgram, OpenAI, Gladia, or Assembly AI in the Settings > Credentials page.
 
+### Note on custom OpenAI proxy servers
+
+To use a custom OpenAI-compatible endpoint (such as a proxy server or alternative model provider), set these environment variables:
+
+- `OPENAI_BASE_URL`: The base URL for your custom endpoint (default: `https://api.openai.com/v1`)
+- `OPENAI_MODEL_NAME`: The model name to use for transcription (default: `gpt-4o-transcribe`)
+
+Example: `OPENAI_BASE_URL=https://your-proxy.com/v1` and `OPENAI_MODEL_NAME=whisper-large-v3`
+
 ## Transcription errors
 
 If you are using third-party-based transcription, you may encounter errors from the transcription provider. These errors are visible in the bot detail page in the dashboard, in the transcription section.


### PR DESCRIPTION
Copied from the [PR](https://github.com/attendee-labs/attendee/pull/283) made by @jeremytregunna 

This PR extends the OpenAI transcription configuration via environment variables, allowing users to set:

- `OPENAI_BASE_URL`
- `OPENAI_MODEL_NAME`

to custom values, such that when transcription is configured with an OpenAI key, and these environment variables are set, the transcription service will call into the custom endpoint, with the custom model name to perform the transcription.

This PR does not change any default behaviour, defaulting to `https://api.openai.com/v1` as the default base url, and `gpt-4o-transcribe` as the default model name.