### PR TITLE
Update recording filename format to include bot ID

### DIFF
--- a/bots/bot_controller/bot_controller.py
+++ b/bots/bot_controller/bot_controller.py
@@ -217,7 +217,7 @@ class BotController:
 
     def get_recording_filename(self):
         recording = Recording.objects.get(bot=self.bot_in_db, is_default_recording=True)
-        return f"{recording.object_id}.{self.bot_in_db.recording_format()}"
+        return f"{self.bot_in_db.object_id}-{recording.object_id}.{self.bot_in_db.recording_format()}"
 
     def on_rtmp_connection_failed(self):
         logger.info("RTMP connection failed")


### PR DESCRIPTION
- Modified get_recording_filename() to include both bot object_id and recording object_id
- Provides better traceability and context for recording files in S3/GCS storage