### PR TITLE
Add intro docs

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,59 +1,49 @@
 # Getting Started with Attendee
 
-Welcome to Attendee! This guide will help you get up and running with meeting bots in minutes.
+Welcome to Attendee! This tutorial will help you get up and running with meeting bots in minutes, using our hosted instance of Attendee.
 
-## What is Attendee?
 
-Attendee is an open-source API that makes it easy to create and manage meeting bots for platforms like Zoom, Google Meet, and Microsoft Teams. With Attendee, you can:
-
-- **Record meetings** - Capture audio and video from virtual meetings
-- **Transcribe conversations** - Get real-time transcription with speaker identification
-- **Send chat messages** - Have your bot participate in meeting chats
-- **Speak into meetings** - Have your bot speak arbitrary audio into the meeting
-
-This tutorial will go through the following steps to get you started with Attendee:
-
-1. **Sign up** for free at [app.attendee.dev](https://app.attendee.dev/accounts/signup/)
-2. **Get your API key** from the "API Keys" section in your dashboard
-3. **Configure credentials** for Zoom, Google Meet, or Teams in the "Settings" section
-4. **Join a meeting** with a simple API call
-5. **Monitor your bot** and retrieve transcripts when the meeting ends
+<scalar-callout type="neutral">Interested in using Attendee at your company? Schedule a call [here](https://calendly.com/noah-attendee/30min). By self-hosting Attendee you can reduce costs by 10x compared to closed source vendors. You may also check out the guide for [running in development mode](docs/self-hosting) for a preview of self-hosting.</scalar-callout>
 
 ## Sign Up
 
-Start with our hosted instance at [app.attendee.dev](https://app.attendee.dev/accounts/signup/) - no credit card required!
+Start with our hosted instance at [app.attendee.dev](https://app.attendee.dev/accounts/signup/). Create an account, and follow the instructions on the **Quick start** section in the sidebar.
 
-## Get Your API Key
+## Create an API key
 
-1. Sign in to your Attendee account
-2. Navigate to the "API Keys" section in the sidebar
-3. Create a new API key for your application
+Sign in to your Attendee account and navigate to the "API Keys" section in the sidebar. Once there, you can create a new API key by giving it a name.
 
 ## Configure Your Credentials
 
-You'll need to set up credentials for the platforms you want to use:
+You'll need to set up credentials for the platforms you want to use. Enter these credentials in the "Settings" section of your Attendee dashboard.
 
 ### For Zoom Meetings:
-- **Zoom OAuth Credentials**: Needed to join Zoom meetings. These are the Zoom app client id and secret that uniquely identify your bot.
+- **Zoom OAuth Credentials**: You'll need these to join Zoom meetings. These are the Zoom app Client ID and secret that uniquely identify your bot.
     1. Navigate to [Zoom Marketplace](https://marketplace.zoom.us/) and register/log into your developer account.
     2. Click the "Develop" button at the top-right, then click 'Build App' and choose "General App".
     3. Copy the Client ID and Client Secret from the 'App Credentials' section
     4. Go to the Embed tab on the left navigation bar under Features, then select the Meeting SDK toggle.
-- **Deepgram API Key**: Needed for transcribing Zoom meetings. You can sign up for an account here, no credit card required and get 400 hours worth of free transcription. Sign up at [Deepgram](https://console.deepgram.com/signup) for transcription (400 free hours included)
+- **Deepgram API Key**: You'll need a Deepgram API key for transcribing Zoom meetings. You can sign up for an account here, no credit card required and get 400 hours worth of free transcription. Sign up at [Deepgram](https://console.deepgram.com/signup) for transcription (400 free hours included)
 
-For more details, follow [this guide](https://developers.zoom.us/docs/meeting-sdk/developer-accounts/) or watch [this video](https://www.loom.com/embed/7cbd3eab1bc4438fb1badcb3787996d6?sid=825a92b5-51ca-447c-86c1-c45f5294ec9d).
+For more details, follow [this guide from Zoom](https://developers.zoom.us/docs/meeting-sdk/developer-accounts/) or watch the video below.
+<scalar-embed
+  src="https://www.loom.com/embed/7cbd3eab1bc4438fb1badcb3787996d6?sid=825a92b5-51ca-447c-86c1-c45f5294ec9d"
+  caption="Setting Up API Calls for Attendee App"
+  alt="Interactive demonstration of getting started with Attendee">
+</scalar-embed>
 
-### For Google Meet:
+### For Google Meet / Microsoft Teams:
 - No additional credentials needed for basic functionality
-
-### For Microsoft Teams:
-- No additional credentials needed for basic functionality
-
-Enter these credentials in the "Settings" section of your Attendee dashboard.
 
 ## Join Your First Meeting
 
-Make a simple API call to join a meeting:
+<scalar-steps>
+<scalar-step id="step-0" title="Start a meeting">
+First, start a meeting in your preferred platform. We'll use Zoom for this example. Copy the meeting URL. You'll need this in the next step.
+</scalar-step>
+
+<scalar-step id="step-1" title="Create a bot to join your meeting">
+With your Attendee API key, send a POST request to join your current meeting:
 
 ```bash
 curl -X POST https://app.attendee.dev/api/v1/bots \
@@ -62,7 +52,7 @@ curl -X POST https://app.attendee.dev/api/v1/bots \
 -d '{"meeting_url": "https://us05web.zoom.us/j/84315220467?pwd=9M1SQg2Pu2l0cB078uz6AHeWelSK19.1", "bot_name": "My Bot"}'
 ```
 
-Response:
+The API will respond with an object that represents your bot's state in the meeting.:
 ```json
 {
   "id":"bot_3hfP0PXEsNinIZmh",
@@ -71,10 +61,14 @@ Response:
   "transcription_state":"not_started"
 }
 ```
+</scalar-step>
+</scalar-steps>
 
 ## Monitor Your Bot
 
-Check your bot's status:
+<scalar-steps>
+<scalar-step id="step-1" title="Get the bot's status">
+Send a GET request to poll the bot:
 
 ```bash
 curl -X GET https://app.attendee.dev/api/v1/bots/bot_3hfP0PXEsNinIZmh \
@@ -91,12 +85,10 @@ Response:
   "transcription_state":"complete"
 }
 ```
-
-When the endpoint returns a state of `ended`, it means the meeting has ended. When the `transcription_state` is `complete` it means the meeting recording has been transcribed.
-
-### Get Your Transcript
-
-Once the meeting has ended and the transcript is ready make a GET request to `/bots/<id>/transcript` to retrieve the meeting transcripts:
+<scalar-callout type="info">When the endpoint returns a state of `ended`, it means the meeting has ended. When the `transcription_state` is `complete` it means the meeting recording has been transcribed.</scalar-callout>
+</scalar-step>
+<scalar-step id="step-2" title="Retrieve the meeting transcripts">
+Once the meeting has ended and the transcript is ready, make a GET request to `/bots/<id>/transcript` to retrieve the meeting transcripts:
 
 ```bash
 curl -X GET https://app.attendee.dev/api/v1/bots/bot_3hfP0PXEsNinIZmh/transcript \
@@ -116,31 +108,25 @@ Response:
 },...]
 ```
 
-You can also query this endpoint while the meeting is happening to retrieve partial transcripts.
+<scalar-callout type="info">You can also query this endpoint while the meeting is happening to retrieve partial transcripts.
+</scalar-callout>
+
+</scalar-step>
+</scalar-steps>
+
+You can also watch this video below which demos the basic API requests.
+<scalar-embed
+  src="https://www.loom.com/embed/b738d02aabf84f489f0bfbadf71605e3?sid=ea605ea9-8961-4cc3-9ba9-10b7dbbb8034"
+  caption="API Requests Tutorial"
+  alt="Interactive demonstration of Attendee API">
+</scalar-embed>
 
 ## Next Steps
 
-- **Learn the basics**: Check out our [Basics guide](./basics) for detailed information about bot capabilities
-- **Set up webhooks**: Configure [webhooks](./webhooks) to get real-time updates about your bots
-- **Schedule bots**: Learn how to [schedule bots](./scheduled_bots) for recurring meetings
-- **Integrate with calendars**: Set up [calendar integration](./calendar_integration) for automatic meeting detection
-- **Explore the API**: View our complete [API documentation](/api-reference)
+<scalar-page-link filepath="docs/basics.md" title="Basics of Bots" description="Read the basics about bots, what they do, and the bot states">
+</scalar-page-link>
 
-## Self-Hosting
+<scalar-page-link filepath="docs/faq.md" title="FAQ" description="For troubleshooting, check out our FAQ page for solutions to common problems">
+</scalar-page-link>
 
-Want to run Attendee on your own infrastructure? Attendee is designed for easy self-hosting and can reduce costs by 10x compared to closed-source alternatives. Check out our [self-hosting guide](../README.md#self-hosting) for instructions.
-
-## Need Help?
-
-- **Documentation**: Browse our comprehensive guides
-- **Community**: Join our [Slack community](https://join.slack.com/t/attendeecommu-rff8300/shared_invite/zt-2uhpam6p2-ZzLAoVrljbL2UEjqdSHrgQ)
-- **Support**: Schedule a call with our team at [calendly.com/noah-attendee/30min](https://calendly.com/noah-attendee/30min)
-- **Issues**: Report bugs or request features on [GitHub](https://github.com/attendee-labs/attendee)
-
-## Common Issues
-
-Having trouble? Check our [FAQ](./faq) for solutions to common problems, including:
-- Setting up Zoom OAuth credentials
-- Troubleshooting bot joining issues
-- Resolving recording problems
-- Local development setup issues
+If you are interested in a self-hosted Attendee solution, try running Attendee in development mode in the next page of the guide.

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -1,6 +1,8 @@
 # Self-Hosting Attendee
 
-Attendee is designed for convenient self-hosting and can reduce costs by 10x compared to closed-source alternatives. This guide will walk you through deploying Attendee on your own infrastructure.
+Attendee is designed for convenient self-hosting, installed via the official Docker image.
+
+This guide will walk you through deploying Attendee on development mode, to preview running it on your own infrastructure.
 
 ## Overview
 
@@ -8,29 +10,26 @@ Attendee runs as a Django application in a single Docker image with minimal exte
 
 - **PostgreSQL** - Database for storing bot data, users, and configurations
 - **Redis** - Message broker for Celery tasks and caching
-- **AWS S3** - Storage for recordings and media files (optional, can use local storage)
+- **AWS S3** (optional) - Storage for meeting recordings and media files. If not configured, files will be stored locally
+
 
 ## Prerequisites
 
-Before you begin, ensure you have:
+Before you begin, ensure you have **Docker** and **Docker Compose** installed on your system. In addition, refer to the Getting Started page for setting up Zoom Oauth and Deepgram for Zoom meetings, if you are using Zoom.
 
-- **Docker and Docker Compose** installed on your system
-- **Git** for cloning the repository
-- **AWS Account** (optional, for S3 storage)
-- **Zoom OAuth Credentials** (if using Zoom meetings)
-- **Deepgram API Key** (for transcription services)
+## Running in Development Mode
 
-## Quick Start
-
-### 1. Clone the Repository
+<scalar-steps>
+<scalar-step id="step-0" title="Clone the Repository">
+Clone the Attendee repository and navigate to the project directory:
 
 ```bash
 git clone https://github.com/attendee-labs/attendee.git
 cd attendee
 ```
+</scalar-step>
 
-### 2. Set Up Environment Variables
-
+<scalar-step id="step-1" title="Set Up Environment Variables">
 Generate the initial environment configuration:
 
 **Linux/Mac:**
@@ -42,292 +41,73 @@ docker compose -f dev.docker-compose.yaml run --rm attendee-app-local python ini
 ```powershell
 docker compose -f dev.docker-compose.yaml run --rm attendee-app-local python init_env.py | Out-File -Encoding utf8 .env
 ```
+</scalar-step>
 
-### 3. Configure Your Environment
-
-Edit the `.env` file and update the following key variables:
+<scalar-step id="step-2" title="Configure Your Environment">
+Edit the initial .env file with AWS configuration, if applicable:
 
 ```bash
-# Database Configuration
-POSTGRES_HOST=postgres
-POSTGRES_DB=attendee_production
-POSTGRES_USER=attendee_user
-POSTGRES_PASSWORD=your_secure_password
-
-# Redis Configuration
-REDIS_URL=redis://redis:6379/5
-
 # AWS Configuration (for S3 storage)
 AWS_ACCESS_KEY_ID=your_aws_access_key
 AWS_SECRET_ACCESS_KEY=your_aws_secret_key
-AWS_REGION=us-east-1
-AWS_S3_BUCKET=your-attendee-bucket
-
-# Django Settings
-SECRET_KEY=your_django_secret_key
-DEBUG=False
-ALLOWED_HOSTS=your-domain.com,localhost
-
-# Email Configuration (for user registration)
-EMAIL_HOST=smtp.gmail.com
-EMAIL_PORT=587
-EMAIL_HOST_USER=your-email@gmail.com
-EMAIL_HOST_PASSWORD=your-app-password
-EMAIL_USE_TLS=True
+AWS_DEFAULT_REGION=us-east-1
+AWS_RECORDING_STORAGE_BUCKET_NAME=your-attendee-bucket
 ```
+</scalar-step>
 
-### 4. Build and Start Services
-
+<scalar-step id="step-3" title="Build and Start Services">
 Build the Docker image (takes about 5 minutes):
+
 ```bash
 docker compose -f dev.docker-compose.yaml build
 ```
 
 Start all services:
+
 ```bash
 docker compose -f dev.docker-compose.yaml up -d
 ```
+</scalar-step>
 
-### 5. Run Database Migrations
+<scalar-step id="step-4" title="Run Database Migrations">
+In a separate terminal, run the database migrations:
 
-In a separate terminal:
 ```bash
 docker compose -f dev.docker-compose.yaml exec attendee-app-local python manage.py migrate
 ```
+</scalar-step>
 
-### 6. Create Your First Account
+<scalar-step id="step-5" title="Create Your First Account">
+Go to localhost:8000 in your browser and create an account. On creation, the email confirmation link for the account will be written to the server logs in the terminal where you ran:
 
-1. Navigate to `http://localhost:8000` in your browser
-2. Create an account
-3. Check the server logs for the confirmation link:
-   ```bash
-   docker compose -f dev.docker-compose.yaml logs attendee-app-local
-   ```
-4. Look for a line like: `http://localhost:8000/accounts/confirm-email/<key>/`
-5. Paste the link into your browser to confirm your account
+```bash
+docker compose -f dev.docker-compose.yaml up
+```
 
-### 7. Configure Platform Credentials
+Look for a line like:
+```
+http://localhost:8000/accounts/confirm-email/<key>/
+```
 
-1. Sign in to your Attendee instance
-2. Navigate to the "Settings" section
-3. Add your Zoom OAuth credentials and Deepgram API key
-4. Create an API key in the "API Keys" section
+Paste the link into your browser to confirm your account.
+</scalar-step>
+
+You should now be able to log in, input your credentials and obtain an API key. API calls should be directed to http://localhost:8000 instead of https://app.attendee.dev.
+</scalar-steps>
+
+### Restarting After Changes
+After making code changes, the Docker process will automatically detect them and restart. No manual rebuild is needed. However, if you have made changes to the database schema, you'll have to run the migration command again.
+
+## Next Steps
+
+Once you have Attendee running locally, you can:
+
+- **Test bot functionality**: Create bots and join meetings using the same API calls as the hosted version
+- **Explore the codebase**: The repository is open source, so you can customize bot behavior and add features
+- **Set up webhooks**: Configure webhooks to receive real-time updates about your bots
+- **Integrate with calendars**: Set up calendar integration for automatic meeting detection
 
 ## Production Deployment
 
-### Using Docker Compose (Recommended)
+For production deployments for use in your organization, please [schedule a call](https://calendly.com/noah-attendee/30min) with our team. We'll help you set up a secure, scalable production environment and provide ongoing support through a dedicated Slack channel.
 
-For production, create a `docker-compose.yaml` file:
-
-```yaml
-version: '3.8'
-
-services:
-  attendee-app:
-    build: .
-    ports:
-      - "8000:8000"
-    environment:
-      - POSTGRES_HOST=postgres
-      - REDIS_URL=redis://redis:6379/5
-      - DJANGO_SETTINGS_MODULE=attendee.settings.production
-    depends_on:
-      - postgres
-      - redis
-    restart: unless-stopped
-
-  attendee-worker:
-    build: .
-    environment:
-      - POSTGRES_HOST=postgres
-      - REDIS_URL=redis://redis:6379/5
-      - DJANGO_SETTINGS_MODULE=attendee.settings.production
-    depends_on:
-      - postgres
-      - redis
-    restart: unless-stopped
-    command: ["/bin/bash", "-c", "/opt/bin/entrypoint.sh && celery -A attendee worker -l INFO"]
-
-  attendee-scheduler:
-    build: .
-    environment:
-      - POSTGRES_HOST=postgres
-      - REDIS_URL=redis://redis:6379/5
-      - DJANGO_SETTINGS_MODULE=attendee.settings.production
-    depends_on:
-      - postgres
-      - redis
-    restart: unless-stopped
-    command: ["/bin/bash", "-c", "/opt/bin/entrypoint.sh && python manage.py run_scheduler"]
-
-  postgres:
-    image: postgres:15.3-alpine
-    environment:
-      POSTGRES_DB: attendee_production
-      POSTGRES_USER: attendee_user
-      POSTGRES_PASSWORD: your_secure_password
-    volumes:
-      - postgres_data:/var/lib/postgresql/data
-    restart: unless-stopped
-
-  redis:
-    image: redis:7-alpine
-    volumes:
-      - redis_data:/data
-    restart: unless-stopped
-
-volumes:
-  postgres_data:
-  redis_data:
-```
-
-### Using Kubernetes
-
-For Kubernetes deployment, you can use the provided Helm charts or create your own manifests. Key considerations:
-
-- **Resource Requirements**: Bots require significant CPU and memory
-- **Persistent Storage**: For PostgreSQL and Redis
-- **Load Balancing**: For high availability
-- **Monitoring**: Prometheus metrics and logging
-
-### Using Cloud Platforms
-
-#### AWS ECS/Fargate
-- Use the provided Docker image
-- Configure RDS for PostgreSQL
-- Use ElastiCache for Redis
-- Set up Application Load Balancer
-
-#### Google Cloud Run
-- Deploy the containerized application
-- Use Cloud SQL for PostgreSQL
-- Use Memorystore for Redis
-
-#### Azure Container Instances
-- Deploy using the Docker image
-- Use Azure Database for PostgreSQL
-- Use Azure Cache for Redis
-
-## Configuration Options
-
-### Environment Variables
-
-| Variable | Description | Required | Default |
-|----------|-------------|----------|---------|
-| `POSTGRES_HOST` | PostgreSQL host | Yes | - |
-| `POSTGRES_DB` | Database name | Yes | `attendee` |
-| `POSTGRES_USER` | Database user | Yes | - |
-| `POSTGRES_PASSWORD` | Database password | Yes | - |
-| `REDIS_URL` | Redis connection URL | Yes | - |
-| `AWS_ACCESS_KEY_ID` | AWS access key | No | - |
-| `AWS_SECRET_ACCESS_KEY` | AWS secret key | No | - |
-| `AWS_REGION` | AWS region | No | `us-east-1` |
-| `AWS_S3_BUCKET` | S3 bucket name | No | - |
-| `SECRET_KEY` | Django secret key | Yes | - |
-| `DEBUG` | Debug mode | No | `False` |
-| `ALLOWED_HOSTS` | Allowed hosts | Yes | - |
-
-### Bot Configuration
-
-Configure bot behavior through the web interface or API:
-
-- **Recording settings**: Audio/video quality, storage location
-- **Transcription settings**: Language, provider selection
-- **Automatic leave settings**: Timeout configurations
-- **Webhook endpoints**: For real-time notifications
-
-## Monitoring and Maintenance
-
-### Health Checks
-
-Monitor the following endpoints:
-- `/health/` - Application health
-- `/api/v1/bots/` - API availability
-- Database connectivity
-- Redis connectivity
-
-### Logs
-
-View logs for different services:
-```bash
-# Application logs
-docker compose logs attendee-app
-
-# Worker logs
-docker compose logs attendee-worker
-
-# Scheduler logs
-docker compose logs attendee-scheduler
-```
-
-### Backup Strategy
-
-1. **Database Backups**: Regular PostgreSQL dumps
-2. **File Storage**: S3 bucket versioning or local backups
-3. **Configuration**: Version control for environment files
-
-### Scaling Considerations
-
-- **Horizontal Scaling**: Run multiple worker instances
-- **Vertical Scaling**: Increase CPU/memory for bot instances
-- **Database Scaling**: Consider read replicas for high traffic
-- **Caching**: Redis for session and API response caching
-
-## Troubleshooting
-
-### Common Issues
-
-1. **Bots not joining meetings**
-   - Check Zoom OAuth credentials
-   - Verify network connectivity
-   - Review bot logs
-
-2. **Transcription failures**
-   - Verify Deepgram API key
-   - Check audio quality settings
-   - Review transcription provider logs
-
-3. **High resource usage**
-   - Monitor bot resource consumption
-   - Adjust bot limits and timeouts
-   - Consider resource quotas
-
-### Getting Help
-
-- **Documentation**: Check other guides in this documentation
-- **Community**: Join our [Slack community](https://join.slack.com/t/attendeecommu-rff8300/shared_invite/zt-2uhpam6p2-ZzLAoVrljbL2UEjqdSHrgQ)
-- **Issues**: Report bugs on [GitHub](https://github.com/attendee-labs/attendee)
-- **Support**: Schedule a call at [calendly.com/noah-attendee/30min](https://calendly.com/noah-attendee/30min)
-
-## Security Considerations
-
-### Network Security
-- Use HTTPS in production
-- Configure firewall rules
-- Implement rate limiting
-- Use VPN for internal deployments
-
-### Data Security
-- Encrypt database connections
-- Use secure API keys
-- Implement proper access controls
-- Regular security updates
-
-### Compliance
-- GDPR compliance for data handling
-- SOC 2 considerations for enterprise deployments
-- HIPAA compliance for healthcare use cases
-
-## Cost Optimization
-
-### Resource Optimization
-- Right-size bot instances
-- Use spot instances where possible
-- Implement auto-scaling
-- Monitor and optimize storage usage
-
-### Alternative Storage
-- Use local storage instead of S3 for small deployments
-- Implement data retention policies
-- Compress recordings and transcripts
-- Use CDN for static assets

--- a/docs/what_is_attendee.md
+++ b/docs/what_is_attendee.md
@@ -1,0 +1,30 @@
+# What is Attendee?
+
+Attendee is an open-source API that makes it easy to create and manage meeting bots for platforms like Zoom, Google Meet, and Microsoft Teams. Bring meeting transcripts and recordings into your product in days instead of months.
+
+## Key Capabilities
+
+**Recording & Transcription**: Automatically capture high-quality audio and video from meetings with real-time transcription supporting 50+ languages and automatic speaker identification.
+
+**Scheduled Bots**: Schedule bots to join meetings at specific times or integrate with Google and Microsoft calendars for automatic meeting detection.
+
+**Real-time Updates**: Receive instant notifications via webhooks when bots join meetings, transcripts are updated, participants join or leave, or chat messages are sent.
+
+**Cross-Platform Support**: Same API works seamlessly across Zoom (with OAuth), Google Meet (browser-based), and Microsoft Teams.
+
+## Why Attendee?
+
+Building meeting bots from scratch requires months of work that can distract from building the application you want. Each platform has different APIs, authentication methods, and technical requirements. Zoom's SDK is low-level and complex, Google Meet has no official API support, and Microsoft Teams has unique requirements.
+
+Attendee abstracts away all this complexity into a single, developer-friendly REST API. Instead of building meeting bot infrastructure from scratch, you can get started in minutes. And instead of paying for expensive options in the current meeting bot space, self-hosting Attendee reduces costs while giving you full control over your deployment and data.
+
+## Advantages Over Competitors
+
+**Complete Data Ownership**: Unlike closed-source solutions like Recall.ai, Attendee's open-source nature allows you to self-host the entire platform, ensuring all meeting data stays within your infrastructure. This eliminates third-party data access concerns and meets strict compliance requirements, such as those in the EU.
+
+**Predictable Costs**: Self-hosting Attendee eliminates usage-based pricing models that can lead to unpredictable costs as you scale. You pay only for your infrastructure, not per meeting or per minute of recording.
+
+**Full Customization**: With access to the source code, you can modify Attendee to fit your specific needs, add custom features, and integrate with existing systems without waiting for vendor updates or approvals.
+
+**No Vendor Lock-in**: Maintain complete control over your meeting bot solution without dependency on a single vendor's roadmap or pricing changes.
+

--- a/scalar.config.json
+++ b/scalar.config.json
@@ -6,53 +6,87 @@
       "name": "Guides",
       "sidebar": [
         {
-          "path": "docs/getting-started.md",
-          "type": "page"
+          "name": "Introduction",
+          "type": "folder",
+          "children": [
+            {
+              "path": "docs/getting-started.md",
+              "type": "page"
+            },
+            {
+              "path": "docs/self-hosting.md",
+              "type": "page"
+            },
+            {
+              "path": "docs/what_is_attendee.md",
+              "type": "page"
+            }
+          ]
         },
         {
-          "path": "docs/self-hosting.md",
-          "type": "page"
+          "name": "Concepts",
+          "type": "folder",
+          "children": [
+            {
+              "path": "docs/basics.md",
+              "type": "page"
+            },
+            {
+              "path": "docs/participant_events.md",
+              "type": "page"
+            },
+            {
+              "path": "docs/transcription.md",
+              "type": "page"
+            }
+          ]
+        },
+        {
+          "name": "Features",
+          "type": "folder",
+          "children": [
+            {
+              "path": "docs/webhooks.md",
+              "type": "page"
+            },
+            {
+              "path": "docs/scheduled_bots.md",
+              "type": "page"
+            },
+            {
+              "path": "docs/signed_in_bots.md",
+              "type": "page"
+            },
+            {
+              "path": "docs/realtime_audio.md",
+              "type": "page"
+            },
+            {
+              "path": "docs/calendar_integration.md",
+              "type": "page"
+            }
+          ]
+        },
+        {
+          "name": "Platforms & Integrations",
+          "type": "folder",
+          "children": [
+            {
+              "path": "docs/zoom_app_review.md",
+              "type": "page"
+            }
+          ]
+        },
+        {
+          "name": "Support",
+          "type": "folder",
+          "children": [
+            {
+              "path": "docs/faq.md",
+              "type": "page"
+            }
+          ]
         }
-        {
-          "path": "docs/basics.md",
-          "type": "page"
-        },
-        {
-          "path": "docs/webhooks.md",
-          "type": "page"
-        },
-        {
-          "path": "docs/transcription.md",
-          "type": "page"
-        },
-        {
-          "path": "docs/participant_events.md",
-          "type": "page"
-        },
-        {
-          "path": "docs/scheduled_bots.md",
-          "type": "page"
-        },
-        {
-          "path": "docs/signed_in_bots.md",
-          "type": "page"
-        },
-        {
-          "path": "docs/realtime_audio.md",
-          "type": "page"
-        },
-        {
-          "path": "docs/calendar_integration.md",
-          "type": "page"
-        },
-        {
-          "path": "docs/zoom_app_review.md",
-          "type": "page"
-        },
-        {
-          "path": "docs/faq.md",
-          "type": "page"
-        },
       ]
     }
   ],


### PR DESCRIPTION
<img width="3819" height="1472" alt="image" src="https://github.com/user-attachments/assets/b2d4277f-67bd-458a-b04a-13d2f4a6b17b" />

Most of this is ripping the README and putting it into the docs, which you see in the three new docs in the "Introduction" folder. I added some sections to the docs, but I really want to expand further in a couple ways:
- Use as much rich text over plain text as possible. I think the Getting Started page I added demonstrates this the best. We'll have to go back to the remaining pages and try to "rich text"-ify them. See for example I took a list of steps in the README into `scalar-steps` with `scalar-callout` boxes. I think using the full range of Scalar components can really make this shine
<img width="867" height="1653" alt="image" src="https://github.com/user-attachments/assets/0e586ce6-9f05-42aa-a804-4bf7d28c0d8c" />

Also
- Add as much multimedia as possible. You already linked those Loom videos but I like that Scalar embeds and autoplays them
- Add more folders or what I would like to think of as "topics". I separated into folders like "Introduction", "Concepts", and "Features" but I'm looking at a competitor's docs and they have way more subdivisions.
- I also want to add a home page, which looks more like a portal. And a theme that isn't the base Scalar theme, as nice as it looks. We want the docs pages to not look like everyone else's docs page.

Try pulling it down and previewing it on your side. I did use AI to help write content but I ended up mostly scrapping what it generated because it sucked. Most sections that aren't ripped from the README or interactive are a frankenstein of AI and manual input.