### PR TITLE
feat: Add delete credentials functionality

### DIFF
--- a/bots/projects_urls.py
+++ b/bots/projects_urls.py
@@ -71,6 +71,11 @@ urlpatterns = [
         name="create-credentials",
     ),
     path(
+        "<str:object_id>/settings/credentials/delete/",
+        projects_views.DeleteCredentialsView.as_view(),
+        name="delete-credentials",
+    ),
+    path(
         "<str:object_id>/webhooks/",
         projects_views.ProjectWebhooksView.as_view(),
         name="project-webhooks",

--- a/bots/templates/projects/partials/assembly_ai_credentials.html
+++ b/bots/templates/projects/partials/assembly_ai_credentials.html
@@ -9,6 +9,18 @@
                 <button class="btn btn-secondary" data-bs-toggle="modal" data-bs-target="#assemblyAICredentialsModal">
                     Edit Credentials
                 </button>
+                <form style="display: inline;" 
+                      hx-post="{% url 'projects:delete-credentials' project.object_id %}"
+                      hx-target="#assembly-ai-credentials-container"
+                      hx-select="#assembly-ai-credentials-container"
+                      hx-swap="outerHTML"
+                      hx-confirm="Are you sure you want to delete these credentials?">
+                    {% csrf_token %}
+                    <input type="hidden" name="credential_type" value="{{ credential_type }}">
+                    <button type="submit" class="btn btn-outline-danger ms-2">
+                        Delete Credentials
+                    </button>
+                </form>
             {% else %}
                 <p>Add credentials to transcribe meetings using Assembly AI's API.</p>
                 <button class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#assemblyAICredentialsModal">

--- a/bots/templates/projects/partials/deepgram_credentials.html
+++ b/bots/templates/projects/partials/deepgram_credentials.html
@@ -9,6 +9,18 @@
                 <button class="btn btn-secondary" data-bs-toggle="modal" data-bs-target="#deepgramCredentialsModal">
                     Edit Credentials
                 </button>
+                <form style="display: inline;" 
+                      hx-post="{% url 'projects:delete-credentials' project.object_id %}"
+                      hx-target="#deepgram-credentials-container"
+                      hx-select="#deepgram-credentials-container"
+                      hx-swap="outerHTML"
+                      hx-confirm="Are you sure you want to delete these credentials?">
+                    {% csrf_token %}
+                    <input type="hidden" name="credential_type" value="{{ credential_type }}">
+                    <button type="submit" class="btn btn-outline-danger ms-2">
+                        Delete Credentials
+                    </button>
+                </form>
             {% else %}
                 <p>Add credentials to transcribe meetings using Deepgram's API.</p>
                 <button class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#deepgramCredentialsModal">

--- a/bots/templates/projects/partials/elevenlabs_credentials.html
+++ b/bots/templates/projects/partials/elevenlabs_credentials.html
@@ -9,6 +9,18 @@
                 <button class="btn btn-secondary" data-bs-toggle="modal" data-bs-target="#elevenlabsCredentialsModal">
                     Edit Credentials
                 </button>
+                <form style="display: inline;" 
+                      hx-post="{% url 'projects:delete-credentials' project.object_id %}"
+                      hx-target="#elevenlabs-credentials-container"
+                      hx-select="#elevenlabs-credentials-container"
+                      hx-swap="outerHTML"
+                      hx-confirm="Are you sure you want to delete these credentials?">
+                    {% csrf_token %}
+                    <input type="hidden" name="credential_type" value="{{ credential_type }}">
+                    <button type="submit" class="btn btn-outline-danger ms-2">
+                        Delete Credentials
+                    </button>
+                </form>
             {% else %}
                 <p>Add credentials to transcribe meetings using Elevenlabs's API.</p>
                 <button class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#elevenlabsCredentialsModal">

--- a/bots/templates/projects/partials/external_media_storage_credentials.html
+++ b/bots/templates/projects/partials/external_media_storage_credentials.html
@@ -12,6 +12,18 @@
                 <button class="btn btn-secondary" data-bs-toggle="modal" data-bs-target="#externalMediaStorageCredentialsModal">
                     Edit Credentials
                 </button>
+                <form style="display: inline;" 
+                      hx-post="{% url 'projects:delete-credentials' project.object_id %}"
+                      hx-target="#external-media-storage-credentials-container"
+                      hx-select="#external-media-storage-credentials-container"
+                      hx-swap="outerHTML"
+                      hx-confirm="Are you sure you want to delete these credentials?">
+                    {% csrf_token %}
+                    <input type="hidden" name="credential_type" value="{{ credential_type }}">
+                    <button type="submit" class="btn btn-outline-danger ms-2">
+                        Delete Credentials
+                    </button>
+                </form>
             {% else %}
                 <p>Add credentials needed to upload media to S3-compatible cloud storage you control.</p>
                 <button class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#externalMediaStorageCredentialsModal">

--- a/bots/templates/projects/partials/gladia_credentials.html
+++ b/bots/templates/projects/partials/gladia_credentials.html
@@ -9,6 +9,18 @@
                 <button class="btn btn-secondary" data-bs-toggle="modal" data-bs-target="#gladiaCredentialsModal">
                     Edit Credentials
                 </button>
+                <form style="display: inline;" 
+                      hx-post="{% url 'projects:delete-credentials' project.object_id %}"
+                      hx-target="#gladia-credentials-container"
+                      hx-select="#gladia-credentials-container"
+                      hx-swap="outerHTML"
+                      hx-confirm="Are you sure you want to delete these credentials?">
+                    {% csrf_token %}
+                    <input type="hidden" name="credential_type" value="{{ credential_type }}">
+                    <button type="submit" class="btn btn-outline-danger ms-2">
+                        Delete Credentials
+                    </button>
+                </form>
             {% else %}
                 <p>Add credentials to transcribe meetings using Gladia's API.</p>
                 <button class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#gladiaCredentialsModal">

--- a/bots/templates/projects/partials/google_tts_credentials.html
+++ b/bots/templates/projects/partials/google_tts_credentials.html
@@ -8,6 +8,18 @@
                 <button class="btn btn-secondary" data-bs-toggle="modal" data-bs-target="#googleTTSCredentialsModal">
                     Edit Credentials
                 </button>
+                <form style="display: inline;" 
+                      hx-post="{% url 'projects:delete-credentials' project.object_id %}"
+                      hx-target="#google-tts-credentials-container"
+                      hx-select="#google-tts-credentials-container"
+                      hx-swap="outerHTML"
+                      hx-confirm="Are you sure you want to delete these credentials?">
+                    {% csrf_token %}
+                    <input type="hidden" name="credential_type" value="{{ credential_type }}">
+                    <button type="submit" class="btn btn-outline-danger ms-2">
+                        Delete Credentials
+                    </button>
+                </form>
             {% else %}
                 <p>Add credentials to let the Bot speak using Google's Text-to-Speech API.</p>
                 <button class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#googleTTSCredentialsModal">

--- a/bots/templates/projects/partials/openai_credentials.html
+++ b/bots/templates/projects/partials/openai_credentials.html
@@ -9,6 +9,18 @@
                 <button class="btn btn-secondary" data-bs-toggle="modal" data-bs-target="#openaiCredentialsModal">
                     Edit Credentials
                 </button>
+                <form style="display: inline;" 
+                      hx-post="{% url 'projects:delete-credentials' project.object_id %}"
+                      hx-target="#openai-credentials-container"
+                      hx-select="#openai-credentials-container"
+                      hx-swap="outerHTML"
+                      hx-confirm="Are you sure you want to delete these credentials?">
+                    {% csrf_token %}
+                    <input type="hidden" name="credential_type" value="{{ credential_type }}">
+                    <button type="submit" class="btn btn-outline-danger ms-2">
+                        Delete Credentials
+                    </button>
+                </form>
             {% else %}
                 <p>Add credentials to transcribe meetings using OpenAI's API.</p>
                 <button class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#openaiCredentialsModal">

--- a/bots/templates/projects/partials/sarvam_credentials.html
+++ b/bots/templates/projects/partials/sarvam_credentials.html
@@ -9,6 +9,18 @@
                 <button class="btn btn-secondary" data-bs-toggle="modal" data-bs-target="#sarvamCredentialsModal">
                     Edit Credentials
                 </button>
+                <form style="display: inline;" 
+                      hx-post="{% url 'projects:delete-credentials' project.object_id %}"
+                      hx-target="#sarvam-credentials-container"
+                      hx-select="#sarvam-credentials-container"
+                      hx-swap="outerHTML"
+                      hx-confirm="Are you sure you want to delete these credentials?">
+                    {% csrf_token %}
+                    <input type="hidden" name="credential_type" value="{{ credential_type }}">
+                    <button type="submit" class="btn btn-outline-danger ms-2">
+                        Delete Credentials
+                    </button>
+                </form>
             {% else %}
                 <p>Add credentials to transcribe meetings using Sarvam's API.</p>
                 <button class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#sarvamCredentialsModal">

--- a/bots/templates/projects/partials/teams_bot_login_credentials.html
+++ b/bots/templates/projects/partials/teams_bot_login_credentials.html
@@ -10,6 +10,18 @@
                 <button class="btn btn-secondary" data-bs-toggle="modal" data-bs-target="#teamsBotLoginCredentialsModal">
                     Edit Credentials
                 </button>
+                <form style="display: inline;" 
+                      hx-post="{% url 'projects:delete-credentials' project.object_id %}"
+                      hx-target="#teams-bot-login-credentials-container"
+                      hx-select="#teams-bot-login-credentials-container"
+                      hx-swap="outerHTML"
+                      hx-confirm="Are you sure you want to delete these credentials?">
+                    {% csrf_token %}
+                    <input type="hidden" name="credential_type" value="{{ credential_type }}">
+                    <button type="submit" class="btn btn-outline-danger ms-2">
+                        Delete Credentials
+                    </button>
+                </form>
             {% else %}
                 <p>Add credentials needed to launch Signed In Teams Bots.</p>
                 <button class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#teamsBotLoginCredentialsModal">

--- a/bots/templates/projects/partials/zoom_credentials.html
+++ b/bots/templates/projects/partials/zoom_credentials.html
@@ -10,6 +10,18 @@
                 <button class="btn btn-secondary" data-bs-toggle="modal" data-bs-target="#credentialsModal">
                     Edit Credentials
                 </button>
+                <form style="display: inline;" 
+                      hx-post="{% url 'projects:delete-credentials' project.object_id %}"
+                      hx-target="#zoom-credentials-container"
+                      hx-select="#zoom-credentials-container"
+                      hx-swap="outerHTML"
+                      hx-confirm="Are you sure you want to delete these credentials?">
+                    {% csrf_token %}
+                    <input type="hidden" name="credential_type" value="{{ credential_type }}">
+                    <button type="submit" class="btn btn-outline-danger ms-2">
+                        Delete Credentials
+                    </button>
+                </form>
             {% else %}
                 <p>Add credentials needed to launch Zoom Bots.</p>
                 <button class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#credentialsModal">

--- a/bots/tests/test_delete_credentials.py
+++ b/bots/tests/test_delete_credentials.py
@@ -1,0 +1,164 @@
+"""
+Tests for the delete credentials functionality.
+"""
+
+from django.contrib.auth import get_user_model
+from django.test import Client, TestCase
+from django.urls import reverse
+
+from bots.models import Credentials, Organization, Project
+
+User = get_user_model()
+
+
+class DeleteCredentialsViewTest(TestCase):
+    """Test the DeleteCredentialsView functionality."""
+
+    def setUp(self):
+        """Set up test data."""
+        self.client = Client()
+
+        # Create test organization
+        self.organization = Organization.objects.create(name="Test Organization")
+
+        # Create test user
+        self.user = User.objects.create_user(username="testuser", email="test@example.com", password="testpass123", organization=self.organization)
+
+        # Create test project
+        self.project = Project.objects.create(name="Test Project", organization=self.organization)
+
+        # Create test credentials for different providers
+        self.deepgram_cred = Credentials.objects.create(project=self.project, credential_type=Credentials.CredentialTypes.DEEPGRAM)
+
+        self.openai_cred = Credentials.objects.create(project=self.project, credential_type=Credentials.CredentialTypes.OPENAI)
+
+        self.zoom_cred = Credentials.objects.create(project=self.project, credential_type=Credentials.CredentialTypes.ZOOM_OAUTH)
+
+    def test_delete_credentials_success(self):
+        """Test successful deletion of credentials."""
+        self.client.force_login(self.user)
+
+        # Verify credential exists
+        self.assertTrue(Credentials.objects.filter(project=self.project, credential_type=Credentials.CredentialTypes.DEEPGRAM).exists())
+
+        # Delete the credential
+        response = self.client.post(reverse("projects:delete-credentials", args=[self.project.object_id]), {"credential_type": Credentials.CredentialTypes.DEEPGRAM, "csrfmiddlewaretoken": "test-token"})
+
+        # Check response
+        self.assertEqual(response.status_code, 200)
+
+        # Verify credential is deleted
+        self.assertFalse(Credentials.objects.filter(project=self.project, credential_type=Credentials.CredentialTypes.DEEPGRAM).exists())
+
+    def test_delete_credentials_invalid_credential_type(self):
+        """Test deletion with invalid credential type."""
+        self.client.force_login(self.user)
+
+        response = self.client.post(
+            reverse("projects:delete-credentials", args=[self.project.object_id]),
+            {
+                "credential_type": 999,  # Invalid credential type
+                "csrfmiddlewaretoken": "test-token",
+            },
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.content.decode(), "Invalid credential type")
+
+    def test_delete_credentials_nonexistent_credential(self):
+        """Test deletion of non-existent credential."""
+        self.client.force_login(self.user)
+
+        # Try to delete a credential that doesn't exist
+        response = self.client.post(
+            reverse("projects:delete-credentials", args=[self.project.object_id]),
+            {
+                "credential_type": Credentials.CredentialTypes.GLADIA,  # Not created in setUp
+                "csrfmiddlewaretoken": "test-token",
+            },
+        )
+
+        # Should still return 200 (successful deletion of nothing)
+        self.assertEqual(response.status_code, 200)
+
+    def test_delete_credentials_unauthorized_user(self):
+        """Test deletion by unauthorized user."""
+        # Create another user from different organization
+        other_org = Organization.objects.create(name="Other Organization")
+        other_user = User.objects.create_user(username="otheruser", email="other@example.com", password="testpass123", organization=other_org)
+
+        self.client.force_login(other_user)
+
+        response = self.client.post(reverse("projects:delete-credentials", args=[self.project.object_id]), {"credential_type": Credentials.CredentialTypes.DEEPGRAM, "csrfmiddlewaretoken": "test-token"})
+
+        # Should be forbidden (403), redirect to login (302), or not found (404)
+        self.assertIn(response.status_code, [403, 302, 404])
+
+    def test_delete_credentials_missing_credential_type(self):
+        """Test deletion without credential_type parameter."""
+        self.client.force_login(self.user)
+
+        response = self.client.post(reverse("projects:delete-credentials", args=[self.project.object_id]), {"csrfmiddlewaretoken": "test-token"})
+
+        self.assertEqual(response.status_code, 400)
+
+    def test_delete_credentials_invalid_credential_type_format(self):
+        """Test deletion with non-integer credential_type."""
+        self.client.force_login(self.user)
+
+        response = self.client.post(reverse("projects:delete-credentials", args=[self.project.object_id]), {"credential_type": "not-a-number", "csrfmiddlewaretoken": "test-token"})
+
+        self.assertEqual(response.status_code, 400)
+
+    def test_delete_credentials_renders_correct_template(self):
+        """Test that deletion renders the correct template for each credential type."""
+        self.client.force_login(self.user)
+
+        # Test Deepgram
+        response = self.client.post(reverse("projects:delete-credentials", args=[self.project.object_id]), {"credential_type": Credentials.CredentialTypes.DEEPGRAM, "csrfmiddlewaretoken": "test-token"})
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("deepgram-credentials-container", response.content.decode())
+
+        # Test OpenAI
+        response = self.client.post(reverse("projects:delete-credentials", args=[self.project.object_id]), {"credential_type": Credentials.CredentialTypes.OPENAI, "csrfmiddlewaretoken": "test-token"})
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("openai-credentials-container", response.content.decode())
+
+        # Test Zoom
+        response = self.client.post(reverse("projects:delete-credentials", args=[self.project.object_id]), {"credential_type": Credentials.CredentialTypes.ZOOM_OAUTH, "csrfmiddlewaretoken": "test-token"})
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("zoom-credentials-container", response.content.decode())
+
+    def test_delete_credentials_unsupported_credential_type(self):
+        """Test deletion with credential type that has no template."""
+        self.client.force_login(self.user)
+
+        # Create a credential with a type that doesn't have a template
+        # (This would be a future credential type not yet supported in the view)
+        response = self.client.post(
+            reverse("projects:delete-credentials", args=[self.project.object_id]),
+            {
+                "credential_type": 999,  # Invalid/unsupported type
+                "csrfmiddlewaretoken": "test-token",
+            },
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.content.decode(), "Invalid credential type")
+
+    def test_delete_credentials_preserves_other_credentials(self):
+        """Test that deleting one credential doesn't affect others."""
+        self.client.force_login(self.user)
+
+        # Verify both credentials exist
+        self.assertTrue(Credentials.objects.filter(project=self.project, credential_type=Credentials.CredentialTypes.DEEPGRAM).exists())
+        self.assertTrue(Credentials.objects.filter(project=self.project, credential_type=Credentials.CredentialTypes.OPENAI).exists())
+
+        # Delete only Deepgram credential
+        response = self.client.post(reverse("projects:delete-credentials", args=[self.project.object_id]), {"credential_type": Credentials.CredentialTypes.DEEPGRAM, "csrfmiddlewaretoken": "test-token"})
+
+        self.assertEqual(response.status_code, 200)
+
+        # Verify Deepgram is deleted but OpenAI remains
+        self.assertFalse(Credentials.objects.filter(project=self.project, credential_type=Credentials.CredentialTypes.DEEPGRAM).exists())
+        self.assertTrue(Credentials.objects.filter(project=self.project, credential_type=Credentials.CredentialTypes.OPENAI).exists())

--- a/docs/transcription.md
+++ b/docs/transcription.md
@@ -56,6 +56,15 @@ Closed caption-based transcription is free.
 
 For third-party-based transcription, you need to add your API Key for a provider like Deepgram, OpenAI, Gladia, or Assembly AI in the Settings > Credentials page.
 
+### Managing credentials
+
+Once you've added credentials for a transcription provider, you can:
+
+- **Edit credentials**: Click the "Edit Credentials" button to update your API key or other credential information
+- **Delete credentials**: Click the "Delete Credentials" button to remove stored credentials for a provider. This will prevent bots from using that provider until new credentials are added.
+
+The delete credentials feature helps with credential lifecycle management, allowing you to easily remove old or compromised API keys and switch between different provider accounts.
+
 ## Transcription errors
 
 If you are using third-party-based transcription, you may encounter errors from the transcription provider. These errors are visible in the bot detail page in the dashboard, in the transcription section.


### PR DESCRIPTION
- Add DeleteCredentialsView to handle credential deletion
- Add delete-credentials URL route for the new view
- Add delete button to all credential templates (Deepgram, OpenAI, Gladia, Assembly AI, Sarvam, ElevenLabs, Zoom, Google TTS, Teams Bot Login, External Media Storage)
- Add comprehensive documentation for credential management
- Add comprehensive test suite with 9 test cases covering:
  - Successful deletion
  - Invalid credential types
  - Non-existent credentials
  - Unauthorized access
  - Missing parameters
  - Template rendering
  - Credential isolation
- All tests passing and code quality checks passed