### PR TITLE
feat: JSON format logs

### DIFF
--- a/attendee/logging.py
+++ b/attendee/logging.py
@@ -1,0 +1,17 @@
+from datetime import datetime, timezone
+
+from pythonjsonlogger import jsonlogger
+
+
+class ISOJsonFormatter(jsonlogger.JsonFormatter):
+    """
+    JSON formatter that adds ISO 8601 timestamp
+    """
+
+    def add_fields(self, log_record, record, message_dict):
+        super().add_fields(log_record, record, message_dict)
+
+        # Add ISO timestamp from the record's created time
+        # record.created is a Unix timestamp (float)
+        dt = datetime.fromtimestamp(record.created, tz=timezone.utc)
+        log_record["timestamp"] = dt.isoformat()

--- a/attendee/settings/production.py
+++ b/attendee/settings/production.py
@@ -1,4 +1,5 @@
 import os
+import sys
 
 import dj_database_url
 
@@ -20,6 +21,7 @@ DATABASES = {
 CELERY_TASK_ACKS_LATE = True
 CELERY_WORKER_PREFETCH_MULTIPLIER = 1
 CELERY_TASK_REJECT_ON_WORKER_LOST = True
+CELERY_WORKER_HIJACK_ROOT_LOGGER = False
 
 SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 SECURE_SSL_REDIRECT = True
@@ -51,9 +53,15 @@ SERVER_EMAIL = os.getenv("SERVER_EMAIL", "noreply@mail.attendee.dev")
 LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,
+    "formatters": {
+        "plain": {"format": "{levelname} {message}", "style": "{"},
+        "json": {"class": "attendee.logging.ISOJsonFormatter", "format": "%(timestamp)s %(name)s %(levelname)s %(message)s"},
+    },
     "handlers": {
         "console": {
             "class": "logging.StreamHandler",
+            "stream": sys.stdout,
+            "formatter": os.getenv("ATTENDEE_LOG_FORMAT"),  # `None` is the default
         },
     },
     "root": {

--- a/requirements.txt
+++ b/requirements.txt
@@ -93,3 +93,4 @@ aiortc==1.10.1
 deepgram-sdk==4.3.0
 azure-identity==1.25.1
 azure-storage-blob==12.26.0
+python-json-logger==4.0.0


### PR DESCRIPTION
Main use case is making "log level" a field so Datadog or log aggregator can parse and filter correctly

Not sure if it'd be better to pull log config into `base.py`

Example
```
attendee-scheduler-local-1  | {"timestamp": "2025-10-16T22:09:31.572540+00:00", "name": "bots.management.commands.run_scheduler", "levelname": "INFO", "message": "Scheduler daemon exited"}
```