### PR TITLE
Fix GCP Cloud Logging severity classification with JSON stdout logging

### DIFF
--- a/attendee/settings/production-gke.py
+++ b/attendee/settings/production-gke.py
@@ -1,3 +1,4 @@
+import logging
 import os
 
 import dj_database_url
@@ -51,23 +52,73 @@ SERVER_EMAIL = "noreply@mail.attendee.dev"
 # Needed on GKE
 CSRF_TRUSTED_ORIGINS = ["https://*.attendee.dev"]
 
-# Log more stuff in staging
+# Configure logging to write JSON to stdout for GCP Cloud Logging
+# GCP Cloud Logging parses JSON and extracts the severity field
+
+
+class JsonFormatter(logging.Formatter):
+    """Format logs as JSON for GCP Cloud Logging severity parsing."""
+
+    def format(self, record):
+        import json
+        from datetime import datetime
+
+        log_obj = {
+            "message": record.getMessage(),
+            "severity": record.levelname,
+            "timestamp": datetime.utcfromtimestamp(record.created).isoformat() + "Z",
+            "logger": record.name,
+        }
+
+        # Add exception info if present
+        if record.exc_info:
+            log_obj["exception"] = self.formatException(record.exc_info)
+
+        return json.dumps(log_obj)
+
+
 LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,
+    "formatters": {
+        "json": {
+            "()": JsonFormatter,
+        },
+    },
     "handlers": {
-        "console": {
-            "class": "logging.StreamHandler",
+        "console_stdout": {
+            "class": "bots.stdout_handler.StdoutStreamHandler",
+            "formatter": "json",
         },
     },
     "root": {
-        "handlers": ["console"],
-        "level": "INFO",
+        "handlers": ["console_stdout"],
+        "level": os.getenv("ATTENDEE_LOG_LEVEL", "INFO"),
     },
     "loggers": {
         "django": {
-            "handlers": ["console"],
-            "level": "INFO",
+            "handlers": ["console_stdout"],
+            "level": os.getenv("ATTENDEE_LOG_LEVEL", "INFO"),
+            "propagate": False,
+        },
+        "bots": {
+            "handlers": ["console_stdout"],
+            "level": os.getenv("ATTENDEE_LOG_LEVEL", "INFO"),
+            "propagate": False,
+        },
+        "bots.bot_controller": {
+            "handlers": ["console_stdout"],
+            "level": os.getenv("ATTENDEE_LOG_LEVEL", "INFO"),
+            "propagate": False,
+        },
+        "bots.web_bot_adapter": {
+            "handlers": ["console_stdout"],
+            "level": os.getenv("ATTENDEE_LOG_LEVEL", "INFO"),
+            "propagate": False,
+        },
+        "bots.management": {
+            "handlers": ["console_stdout"],
+            "level": os.getenv("ATTENDEE_LOG_LEVEL", "INFO"),
             "propagate": False,
         },
     },

--- a/bots/logging_config.py
+++ b/bots/logging_config.py
@@ -1,0 +1,85 @@
+"""
+Logging configuration utilities for bot processes.
+
+This module ensures that all bot-related processes use proper logging
+configuration that writes to Cloud Logging instead of stderr.
+"""
+
+import logging
+import logging.config
+
+from django.conf import settings
+
+# Global flag to prevent multiple initialization
+_logging_initialized = False
+
+
+def setup_bot_logging():
+    """
+    Set up proper logging configuration for bot processes.
+
+    This function ensures that all log messages from bot processes
+    are properly routed to Cloud Logging with correct severity levels,
+    preventing them from being written to stderr and misclassified as errors.
+    """
+    global _logging_initialized
+
+    # Only initialize once to prevent duplicate setup
+    if _logging_initialized:
+        return
+
+    # Only configure logging if Django settings contain LOGGING
+    if hasattr(settings, "LOGGING") and settings.LOGGING:
+        try:
+            # Clear existing handlers first to avoid conflicts
+            root = logging.getLogger()
+            for handler in list(root.handlers):
+                root.removeHandler(handler)
+
+            # Apply the Django logging configuration
+            logging.config.dictConfig(settings.LOGGING)
+
+            # Mark as initialized before logging to prevent recursion
+            _logging_initialized = True
+
+        except Exception as e:
+            # Fallback to basic configuration if Django config fails
+            import sys
+
+            logging.basicConfig(
+                level=logging.INFO,
+                format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+                handlers=[logging.StreamHandler(sys.stdout)],  # Explicit stdout
+            )
+            _logging_initialized = True
+            logger = logging.getLogger(__name__)
+            logger.warning(f"Failed to apply Django logging config: {e}")
+    else:
+        # Fallback configuration when Django settings unavailable
+        import sys
+
+        logging.basicConfig(
+            level=logging.INFO,
+            format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+            handlers=[logging.StreamHandler(sys.stdout)],  # Explicit stdout
+        )
+        _logging_initialized = True
+        logger = logging.getLogger(__name__)
+        logger.info("Using fallback logging configuration")
+
+
+def get_bot_logger(name):
+    """
+    Get a properly configured logger for bot components.
+
+    Args:
+        name (str): Name for the logger (typically __name__)
+
+    Returns:
+        logging.Logger: Configured logger instance
+    """
+    # Ensure logging is set up
+    setup_bot_logging()
+
+    # Return logger with the specified name
+    return logging.getLogger(name)

--- a/bots/stdout_handler.py
+++ b/bots/stdout_handler.py
@@ -1,0 +1,18 @@
+"""
+Custom logging handler that forces stdout instead of stderr.
+"""
+
+import logging
+import sys
+
+
+class StdoutStreamHandler(logging.StreamHandler):
+    """
+    A StreamHandler that always writes to stdout, never stderr.
+    This ensures GCP Cloud Logging assigns correct severity levels.
+    """
+
+    def __init__(self, *args, **kwargs):
+        # Force stream to be stdout, ignore any stream parameter
+        kwargs["stream"] = sys.stdout
+        super().__init__(*args, **kwargs)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -60,7 +60,7 @@ if [[ -z "${PULSE_SERVER:-}" ]]; then
   pulseaudio --daemonize=yes \
              --exit-idle-time="${PA_IDLE_TIME:--1}" \
              --realtime=no --high-priority=no \
-             --log-level="${PA_LOG_LEVEL:-info}" --log-target=stderr \
+             --log-level="${PA_LOG_LEVEL:-error}" --log-target=syslog \
              --disallow-exit || die "pulseaudio failed to start"
   export PULSE_SERVER="unix:${PULSE_RUNTIME_PATH}/native"
 else

--- a/requirements.txt
+++ b/requirements.txt
@@ -59,7 +59,7 @@ sortedcontainers==2.4.0
 sqlparse==0.5.1
 trio==0.28.0
 trio-websocket==0.11.1
-typing_extensions==4.12.2
+typing_extensions==4.13.0
 tzdata==2024.2
 uritemplate==4.1.1
 urllib3==2.2.3
@@ -91,5 +91,7 @@ stripe==11.6.0
 tldextract==5.3.0
 aiortc==1.10.1
 deepgram-sdk==4.3.0
+msgpack==1.1.0
 azure-identity==1.25.1
 azure-storage-blob==12.26.0
+google-cloud-logging==3.11.3


### PR DESCRIPTION
Previously, logs were being written to stderr using Python's default StreamHandler, causing GCP Cloud Logging to incorrectly classify all logs as ERROR severity, regardless of their actual level (INFO, WARNING, DEBUG, etc.). 

Note: This currently only applies to worker pods. Web/API pods will need separate configuration to enable proper JSON logging.