### PR TITLE
fix deliver_webhook task emitting before transaction commit 

### DIFF
--- a/bots/webhook_utils.py
+++ b/bots/webhook_utils.py
@@ -4,6 +4,7 @@ import hmac
 import json
 import logging
 import uuid
+from functools import partial
 
 from django.db import transaction
 
@@ -56,7 +57,7 @@ def trigger_webhook(webhook_trigger_type, bot=None, calendar=None, zoom_oauth_co
 
         from bots.tasks.deliver_webhook_task import deliver_webhook
 
-        transaction.on_commit(lambda: deliver_webhook.delay(delivery_attempt.id))
+        transaction.on_commit(partial(deliver_webhook.delay, delivery_attempt.id))
 
     return len(delivery_attempts)
 


### PR DESCRIPTION
Ensure deliver_webhook task reads committed WebhookDeliveryAttempt

- Wrap task trigger in `transaction.on_commit` to avoid DoesNotExist errors
  when the row hasn’t been committed yet.

getting a lot of does not exist 
<img width="1178" height="352" alt="Screenshot 2025-11-13 at 4 42 34 PM" src="https://github.com/user-attachments/assets/8735de9c-562d-46db-b0f5-3693665397b2" />
