### PR TITLE
turn off chrome sandboxing in dev

### DIFF
--- a/dev.docker-compose.yaml
+++ b/dev.docker-compose.yaml
@@ -9,10 +9,8 @@ services:
       - POSTGRES_HOST=postgres
       - REDIS_URL=redis://redis:6379/5
       - DJANGO_SETTINGS_MODULE=attendee.settings.development
-      - ENABLE_CHROME_SANDBOX=true
+      - ENABLE_CHROME_SANDBOX=false
     command: "celery -A attendee worker -l INFO"
-    security_opt:
-      - seccomp=./bots/web_bot_adapter/chrome_seccomp.json
 
   attendee-scheduler-local:
     build: ./


### PR DESCRIPTION
Reverts to the old way of doing things, the new way was causing problems for running locally for too many people.