### PR TITLE
feat: add component label to bot processes

### DIFF
--- a/bots/bot_pod_creator/bot_pod_creator.py
+++ b/bots/bot_pod_creator/bot_pod_creator.py
@@ -311,6 +311,7 @@ class BotPodCreator:
             "app.kubernetes.io/instance": self.app_instance,
             "app.kubernetes.io/version": self.app_version,
             "app.kubernetes.io/managed-by": "cuber",
+            "app.kubernetes.io/component": "bot-proc",
             "app": "bot-proc",
         }
         if add_webpage_streamer:


### PR DESCRIPTION
our metrics system (Datadog) automatically tracks common labels https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/#labels so populating component will allow easily slicing/monitoring bot processes from other pods and jobs in the same namespace