### PR TITLE
Smart bot filtering for auto-leave

### DIFF
--- a/bots/automatic_leave_configuration.py
+++ b/bots/automatic_leave_configuration.py
@@ -7,14 +7,14 @@ class AutomaticLeaveConfiguration:
 
     Attributes:
         silence_timeout_seconds: Number of seconds of continuous silence after which the bot should leave
-        only_participant_in_meeting_timeout_seconds: Number of seconds to wait before leaving if bot is the only participant (bots matching bot_name_patterns are excluded from participant count)
+        only_participant_in_meeting_timeout_seconds: Number of seconds to wait before leaving if bot is the only participant (participants with names containing bot_keywords are excluded)
         wait_for_host_to_start_meeting_timeout_seconds: Number of seconds to wait for the host to start the meeting
         silence_activate_after_seconds: Number of seconds to wait before activating the silence timeout
         waiting_room_timeout_seconds: Number of seconds to wait before leaving if the bot is in the waiting room
         max_uptime_seconds: Maximum number of seconds that the bot should be running before automatically leaving (infinite by default)
         enable_closed_captions_timeout_seconds: Number of seconds to wait before leaving if bot could not enable closed captions (infinite by default)
         authorized_user_not_in_meeting_timeout_seconds: Number of seconds to wait before leaving if the authorized user is not in the meeting. Only relevant if this is a Zoom bot using the on behalf of token.
-        bot_name_patterns: List of regex patterns to identify bot participants. Participants matching these patterns are excluded from the "only participant" check.
+        bot_keywords: List of keywords to identify bot participants. A participant is considered a bot if any word in their name matches a keyword (case-insensitive).
     """
 
     silence_timeout_seconds: int = 600
@@ -25,4 +25,4 @@ class AutomaticLeaveConfiguration:
     max_uptime_seconds: int | None = None
     enable_closed_captions_timeout_seconds: int | None = None
     authorized_user_not_in_meeting_timeout_seconds: int = 600
-    bot_name_patterns: list[str] | None = None
+    bot_keywords: list[str] | None = None

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -2630,11 +2630,11 @@ components:
                 user is not in the meeting. Only relevant if this is a Zoom bot using
                 the on behalf of token.
               default: 600
-            bot_name_patterns:
+            bot_keywords:
               type: array
               items:
                 type: string
-              description: List of regex patterns (case-insensitive) to identify bot participants. Participants matching these patterns are excluded from the 'only participant' check. If only bots remain in a meeting, the bot will leave after the configured timeout (only_participant_in_meeting_timeout_seconds).
+              description: List of keywords to identify bot participants. A participant is considered a bot if any word in their name (split on spaces, hyphens, underscores) matches a keyword (case-insensitive). If only bots remain, the bot leaves after the configured timeout.
               nullable: true
               default: null
           required: []


### PR DESCRIPTION
## 🎯 Problem

When multiple recording bots join a meeting (Fireflies, Otter.ai, Grain, etc.), our bot should recognize them and leave automatically when only bots remain - just like it would if it were the only participant.

## 💡 Solution

Filter out bot participants when counting humans in the meeting using simple keyword matching.

### How it works

**New parameter: `bot_keywords`**
```json
{
  "automatic_leave_settings": {
    "only_participant_in_meeting_timeout_seconds": 60,
    "bot_keywords": ["Bot", "Fireflies", "Otter", "Grain", "Recorder", "Notetaker"]
  }
}
```

**Logic:**
1. 🔍 **Split participant names** on spaces, hyphens, and underscores
2. 🔎 **Match keywords** case-insensitively against each word
3. ⏱️ **Reuse existing timer**: When only bots remain, the existing `only_participant_in_meeting` check activates
4. 🚪 **Graceful exit**: Bot leaves after the configured timeout

**Example:**
- `"Meeting Bot"` → words: `["Meeting", "Bot"]` → matches keyword `"Bot"` ✅
- `"Carole Bothin"` → words: `["Carole", "Bothin"]` → does NOT match `"Bot"` ✅
- `"fireflies-recorder"` → words: `["fireflies", "recorder"]` → matches keywords ✅

## ✨ Advantages

- ✅ **Simple**: No regex complexity, just keyword list
- ✅ **Safe**: Won't match partial words (e.g., "Bothin" ≠ "Bot")
- ✅ **DRY**: Reuses existing auto-leave logic
- ✅ **Maintainable**: Less code, fewer edge cases

## 🔧 Technical Details

**Files modified:**
- `AutomaticLeaveConfiguration`: Add `bot_keywords` parameter
- `WebBotAdapter` & `ZoomBotAdapter`: Filter bots via `_is_bot_name()` / `_is_bot_participant()`
- `Serializers`: Simple string list validation
- `OpenAPI`: Complete documentation

## 🎪 Use Cases

**Scenario 1: Meeting with 5 recording bots**
- 10 humans + 5 bots join meeting
- Meeting ends, all 10 humans leave
- Only 5 bots remain → Our bot counts 0 humans → Leaves after 60s ✅

**Scenario 2: Human with bot-like name**
- "Carole Bothin" joins → NOT matched as bot ✅
- "Meeting Bot" joins → Matched as bot ✅

## 🧪 Testing

- ✅ Ruff checks passed
- ✅ Case-insensitive matching confirmed
- ✅ Word boundary matching working

---

**Credit:** Refactored based on [@noahlt](https://github.com/noahlt)'s suggestion to use keywords instead of regex 🙏