### PR TITLE
Add data deletion documentation to basics.md

### DIFF
--- a/docs/basics.md
+++ b/docs/basics.md
@@ -23,6 +23,7 @@ Bots go through these lifecycle states:
 7. Fatal Error: Bot encountered an unrecoverable error
 8. Waiting Room: Bot is in meeting's waiting room
 9. Ended: Bot has completed all tasks and recordings and transcripts are available for download
+10. Data Deleted: Bot data has been permanently deleted (recordings, transcripts, participants)
 
 ## Transcription Features
 
@@ -60,3 +61,14 @@ Currently supported platforms:
 1. Zoom
 2. Google Meet
 3. Microsoft Teams
+
+## Data Deletion
+You can permanently delete all data associated with a bot, including recordings, transcripts, and participant information. 
+
+To delete bot data, use the `POST /api/v1/bots/{bot_id}/delete_data` endpoint. This action:
+- Is irreversible and cannot be undone
+- Only works for bots in the `ended` or `fatal_error` states
+- Preserves bot metadata for audit purposes
+- Moves the bot to the `data_deleted` state
+
+Note: Metadata fields (like bot ID, meeting URL, creation time) are retained for audit purposes even after data deletion.


### PR DESCRIPTION
- Added DATA_DELETED state (10) to bot states list
- Added comprehensive Data Deletion section explaining:
  - What data gets deleted (recordings, transcripts, participants)
  - API endpoint usage (POST /api/v1/bots/{bot_id}/delete_data)
  - State requirements (ended or fatal_error)
  - Metadata retention for audit compliance
  - Irreversible nature of the operation
