### PR TITLE
fix: load environment variables from .env in dev docker-compose

### DIFF
--- a/dev.docker-compose.yaml
+++ b/dev.docker-compose.yaml
@@ -3,6 +3,8 @@ services:
     build: ./
     volumes:
      - .:/attendee
+    env_file:         # <--- Add this line
+      - .env
     networks:
       - attendee_network
     environment:


### PR DESCRIPTION
- While setting up the development environment on macOS (M1/ARM64), the attendee-app-local container fails with django.core.exceptions.
- ImproperlyConfigured: The **SECRET_KEY** setting must not be empty. 
- Cause: The dev.docker-compose.yaml does not use the env_file directive, so local .env variables aren't passed to the container unless explicitly defined in the YAML. 
- Proposed Fix: _Add env_file: .env_ to the relevant services in dev.docker-compose.yaml.