### PR TITLE
refactor(ui): move sidebar styles to theme.css and prep dark mode

### DIFF
--- a/static/css/theme.css
+++ b/static/css/theme.css
@@ -1,0 +1,39 @@
+/* Sidebar base styles */
+.sidebar {
+    min-height: 100vh;
+    background-color: #f8f9fa;
+    border-right: 1px solid #dee2e6;
+}
+
+.sidebar .nav-link {
+    color: #333;
+    padding: 0.5rem 1rem;
+    cursor: pointer;
+}
+
+.sidebar .nav-link:hover {
+    background-color: #e9ecef;
+}
+
+.sidebar .nav-link.active {
+    background-color: #0d6efd;
+    color: white;
+}
+/* Dark mode sidebar styles (Bootstrap 5.3 compatible) */
+[data-bs-theme="dark"] .sidebar {
+    background-color: #1e1e1e;
+    border-right: 1px solid #2a2a2a;
+}
+
+[data-bs-theme="dark"] .sidebar .nav-link {
+    color: #e0e0e0;
+}
+
+[data-bs-theme="dark"] .sidebar .nav-link:hover {
+    background-color: #2a2a2a;
+}
+
+[data-bs-theme="dark"] .sidebar .nav-link.active {
+    background-color: #0d6efd;
+    color: #ffffff;
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -7,29 +7,11 @@
     <!-- Bootstrap CSS -->
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.0/font/bootstrap-icons.css">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="{% static 'css/theme.css' %}">
+
     <!-- HTMX -->
     <!--  <script src="https://unpkg.com/htmx.org@2.0.3"></script>  -->
     <script src="https://unpkg.com/htmx.org@2.0.3/dist/htmx.js"></script>
-
-    <style>
-        .sidebar {
-            min-height: 100vh;
-            background-color: #f8f9fa;
-            border-right: 1px solid #dee2e6;
-        }
-        .sidebar .nav-link {
-            color: #333;
-            padding: 0.5rem 1rem;
-            cursor: pointer;
-        }
-        .sidebar .nav-link:hover {
-            background-color: #e9ecef;
-        }
-        .sidebar .nav-link.active {
-            background-color: #0d6efd;
-            color: white;
-        }
-    </style>
 </head>
 <body>
     {% if messages and 'accounts' in request.path %}


### PR DESCRIPTION
### Summary
This PR makes a small UI-only refactor by moving sidebar styles out of `base.html` into a centralized `theme.css`.
It also prepares the sidebar for Bootstrap 5.3 dark mode using `data-bs-theme="dark"` selectors.

### What changed
- Moved inline sidebar styles from `base.html` to `static/css/theme.css`
- Added dark-mode-ready sidebar styles (no behavior change)
- Linked the new theme stylesheet after Bootstrap

### Scope
- UI-only changes
- No backend, API, or logic changes

### Related Issue
Closes #597
