### PR TITLE
fix(calendar): refresh calendar after Microsoft token rotation to avo…

### DIFF
--- a/bots/tasks/sync_calendar_task.py
+++ b/bots/tasks/sync_calendar_task.py
@@ -702,6 +702,7 @@ class MicrosoftCalendarSyncHandler(CalendarSyncHandler):
             if new_refresh and new_refresh != refresh_token:
                 credentials["refresh_token"] = new_refresh
                 self.calendar.set_credentials(credentials)
+                self.calendar.refresh_from_db()
                 logger.info("Stored rotated Microsoft refresh_token for calendar %s", self.calendar.object_id)
 
             return access_token


### PR DESCRIPTION
## Fix RecordModifiedError on calendar sync (Microsoft)

### Problem
Calendar sync could fail with `RecordModifiedError: Record has been modified` when using Microsoft calendars. The error happened at the final `calendar.save()` in `sync_events()`.

### Cause
The same calendar is saved twice in one sync run:
1. **Token rotation** – When Microsoft returns a new `refresh_token`, `set_credentials()` is called and does a `calendar.save()`, so the DB version is incremented.
2. **End of sync** – We update `last_successful_sync_at`, etc. and call `calendar.save()` again.

The in-memory calendar instance was not refreshed after the first save, so it still had the old version. The second save then did `UPDATE ... WHERE version=N` while the DB was already at N+1, and django-concurrency raised `RecordModifiedError`.

### Solution
After `set_credentials()` in `MicrosoftCalendarSyncHandler._get_access_token()`, call `self.calendar.refresh_from_db()` so the instance has the current version before the final save in `sync_events()`.