### PR TITLE
Get rid of bot launcher app, just rely on separate queue

### DIFF
--- a/attendee/settings/base.py
+++ b/attendee/settings/base.py
@@ -38,7 +38,6 @@ INSTALLED_APPS = [
     "allauth.socialaccount",
     "accounts",
     "bots",
-    "bot_launcher",
     "rest_framework",
     "concurrency",
     "allauth.socialaccount.providers.google",

--- a/bot_launcher/__init__.py
+++ b/bot_launcher/__init__.py
@@ -1,2 +1,0 @@
-# Bot launcher Django app (tasks use attendee Celery app, queue bot_launcher)
-default_app_config = 'bot_launcher.apps.BotLauncherConfig'

--- a/bot_launcher/apps.py
+++ b/bot_launcher/apps.py
@@ -1,6 +1,0 @@
-from django.apps import AppConfig
-
-
-class BotLauncherConfig(AppConfig):
-    default_auto_field = 'django.db.models.BigAutoField'
-    name = 'bot_launcher'

--- a/bot_launcher/management/__init__.py
+++ b/bot_launcher/management/__init__.py
@@ -1,1 +1,0 @@
-# Django management commands for bot_launcher

--- a/bot_launcher/management/commands/__init__.py
+++ b/bot_launcher/management/commands/__init__.py
@@ -1,1 +1,0 @@
-# Django management commands

--- a/bots/tasks/__init__.py
+++ b/bots/tasks/__init__.py
@@ -5,6 +5,7 @@ from .process_async_transcription_task import process_async_transcription
 from .process_utterance_task import process_utterance
 from .refresh_zoom_oauth_connection_task import refresh_zoom_oauth_connection
 from .restart_bot_pod_task import restart_bot_pod
+from .run_bot_in_ephemeral_container_task import run_bot_in_ephemeral_container
 from .run_bot_task import run_bot
 from .send_slack_alert_task import send_slack_alert
 from .sync_calendar_task import sync_calendar
@@ -25,4 +26,5 @@ __all__ = [
     "refresh_zoom_oauth_connection",
     "validate_zoom_oauth_connections",
     "send_slack_alert",
+    "run_bot_in_ephemeral_container",
 ]


### PR DESCRIPTION
Having that separate bot launcher app looked a bit odd, because in Django app's are used to separate big parts of the application like "user management" vs "bot management".

This PR just splits the tasks up only on via queues. The ephemeral container bot tasks will go into a special queue called `bot_launcher_vm`. All other tasks will be launched on the default queue, which is called `celery`