### PR TITLE
Feature: Add support for Redis cluster and SSL requirements

### DIFF
--- a/attendee/celery.py
+++ b/attendee/celery.py
@@ -6,13 +6,36 @@ from celery import Celery
 # Set the default Django settings module
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "attendee.settings")
 
-# Create the Celery app
+sslCertRequirements = None
 if os.getenv("DISABLE_REDIS_SSL"):
+    sslCertRequirements = ssl.CERT_NONE
+elif os.getenv("REDIS_SSL_REQUIREMENTS") is not None and os.getenv("REDIS_SSL_REQUIREMENTS") != "":
+    if os.getenv("REDIS_SSL_REQUIREMENTS") == "none":
+        sslCertRequirements = ssl.CERT_NONE
+    elif os.getenv("REDIS_SSL_REQUIREMENTS") == "optional":
+        sslCertRequirements = ssl.CERT_OPTIONAL
+    elif os.getenv("REDIS_SSL_REQUIREMENTS") == "required":
+        sslCertRequirements = ssl.CERT_REQUIRED
+
+# Create the Celery app
+if sslCertRequirements is not None:
     app = Celery(
         "attendee",
-        broker_use_ssl={"ssl_cert_reqs": ssl.CERT_NONE},
-        redis_backend_use_ssl={"ssl_cert_reqs": ssl.CERT_NONE},
+        broker_use_ssl={"ssl_cert_reqs": sslCertRequirements},
+        redis_backend_use_ssl={"ssl_cert_reqs": sslCertRequirements},
     )
+    # If we are sure that we are using SSL enable support for Redis Cluster hash
+    # tags. This is mainly to prevent CROSSSLOT errors when using Redis Cluster.
+    #
+    # https://github.com/celery/celery/issues/8276#issuecomment-3714489309
+    if sslCertRequirements == ssl.CERT_REQUIRED:
+        app.conf.update(
+            broker_transport_options={
+                "global_keyprefix": "{celeryattendee}:",
+                "fanout_prefix": True,
+                "fanout_patterns": True,
+            },
+        )
 else:
     app = Celery("attendee")
 

--- a/attendee/settings/base.py
+++ b/attendee/settings/base.py
@@ -161,10 +161,14 @@ STATIC_URL = "static/"
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 # Redis/Celery Configuration
-if os.getenv("DISABLE_REDIS_SSL"):
-    REDIS_CELERY_URL = os.getenv("REDIS_URL") + "?ssl_cert_reqs=none"
-else:
-    REDIS_CELERY_URL = os.getenv("REDIS_URL")
+redis_params = {}
+if os.getenv("DISABLE_REDIS_SSL"): # backward compatibility
+    redis_params["ssl_cert_reqs"] = "none"
+elif os.getenv("REDIS_SSL_REQUIREMENTS") is not None and os.getenv("REDIS_SSL_REQUIREMENTS") != "":
+    redis_params["ssl_cert_reqs"] = os.getenv("REDIS_SSL_REQUIREMENTS")
+redis_params_query_string = "&".join([f"{key}={value}" for key, value in redis_params.items()])
+
+REDIS_CELERY_URL = os.getenv("REDIS_URL") + ("?" + redis_params_query_string if redis_params_query_string else "")
 
 CELERY_BROKER_URL = REDIS_CELERY_URL
 CELERY_RESULT_BACKEND = REDIS_CELERY_URL

--- a/bots/bot_sso_utils.py
+++ b/bots/bot_sso_utils.py
@@ -35,7 +35,13 @@ def get_google_meet_set_cookie_url(session_id):
 def create_google_meet_sign_in_session(bot: Bot, google_meet_bot_login: GoogleMeetBotLogin):
     session_id = str(uuid.uuid4())
     redis_key = f"google_meet_sign_in_session:{session_id}"
-    redis_url = os.getenv("REDIS_URL") + ("?ssl_cert_reqs=none" if os.getenv("DISABLE_REDIS_SSL") else "")
+    redis_params = {}
+    if os.getenv("DISABLE_REDIS_SSL"): # backward compatibility
+        redis_params["ssl_cert_reqs"] = "none"
+    elif os.getenv("REDIS_SSL_REQUIREMENTS") is not None and os.getenv("REDIS_SSL_REQUIREMENTS") != "":
+        redis_params["ssl_cert_reqs"] = os.getenv("REDIS_SSL_REQUIREMENTS")
+    redis_params_query_string = "&".join([f"{key}={value}" for key, value in redis_params.items()])
+    redis_url = os.getenv("REDIS_URL") + ("?" + redis_params_query_string if redis_params_query_string else "")
     redis_client = redis.from_url(redis_url)
     # Save for 30 minutes
     session_data = {
@@ -48,7 +54,13 @@ def create_google_meet_sign_in_session(bot: Bot, google_meet_bot_login: GoogleMe
 
 def get_bot_login_for_google_meet_sign_in_session(session_id):
     redis_key = f"google_meet_sign_in_session:{session_id}"
-    redis_url = os.getenv("REDIS_URL") + ("?ssl_cert_reqs=none" if os.getenv("DISABLE_REDIS_SSL") else "")
+    redis_params = {}
+    if os.getenv("DISABLE_REDIS_SSL"): # backward compatibility
+        redis_params["ssl_cert_reqs"] = "none"
+    elif os.getenv("REDIS_SSL_REQUIREMENTS") is not None and os.getenv("REDIS_SSL_REQUIREMENTS") != "":
+        redis_params["ssl_cert_reqs"] = os.getenv("REDIS_SSL_REQUIREMENTS")
+    redis_params_query_string = "&".join([f"{key}={value}" for key, value in redis_params.items()])
+    redis_url = os.getenv("REDIS_URL") + ("?" + redis_params_query_string if redis_params_query_string else "")
     redis_client = redis.from_url(redis_url)
     session_data_raw = redis_client.get(redis_key)
     if not session_data_raw:
@@ -58,7 +70,7 @@ def get_bot_login_for_google_meet_sign_in_session(session_id):
     try:
         session_data = json.loads(session_data_raw)
     except Exception as e:
-        logger.warning(f"Error loading session data for google_meet_sign_in_session: {session_id}. Data: {session_data}. Error: {e}")
+        logger.warning(f"Error loading session data for google_meet_sign_in_session: {session_id}. Data: {session_data_raw}. Error: {e}")
         return None
 
     bot_object_id = session_data.get("bot_object_id")

--- a/bots/bots_api_utils.py
+++ b/bots/bots_api_utils.py
@@ -59,7 +59,13 @@ def build_site_url(path=""):
 
 
 def send_sync_command(bot, command="sync"):
-    redis_url = os.getenv("REDIS_URL") + ("?ssl_cert_reqs=none" if os.getenv("DISABLE_REDIS_SSL") else "")
+    redis_params = {}
+    if os.getenv("DISABLE_REDIS_SSL"): # backward compatibility
+        redis_params["ssl_cert_reqs"] = "none"
+    elif os.getenv("REDIS_SSL_REQUIREMENTS") is not None and os.getenv("REDIS_SSL_REQUIREMENTS") != "":
+        redis_params["ssl_cert_reqs"] = os.getenv("REDIS_SSL_REQUIREMENTS")
+    redis_params_query_string = "&".join([f"{key}={value}" for key, value in redis_params.items()])
+    redis_url = os.getenv("REDIS_URL") + ("?" + redis_params_query_string if redis_params_query_string else "")
     redis_client = redis.from_url(redis_url)
     channel = f"bot_{bot.id}"
     message = {"command": command}


### PR DESCRIPTION
Following [discussions from Celery](https://github.com/celery/celery/issues/8276#issuecomment-3714489309), this adds support for Redis cluster, and also allows using TLS connections.

When connecting to Redis using TLS, the `ssl_cert_reqs` parameter must be provided.

> URL must have parameter ssl_cert_reqs and this must be set to CERT_REQUIRED,
> CERT_OPTIONAL, or CERT_NONE

The new `REDIS_SSL_REQUIREMENTS` environment variable allows setting this value.