### PR TITLE
Add 480p as supported recording resolution

### DIFF
--- a/bots/models.py
+++ b/bots/models.py
@@ -2019,6 +2019,7 @@ class RecordingTypes(models.IntegerChoices):
 class RecordingResolutions(models.TextChoices):
     HD_1080P = "1080p"
     HD_720P = "720p"
+    SD_480P = "480p"
 
     @classmethod
     def get_dimensions(cls, value):
@@ -2026,6 +2027,7 @@ class RecordingResolutions(models.TextChoices):
         dimensions = {
             cls.HD_1080P: (1920, 1080),
             cls.HD_720P: (1280, 720),
+            cls.SD_480P: (854, 480),
         }
         return dimensions.get(value)
 

--- a/bots/serializers.py
+++ b/bots/serializers.py
@@ -644,7 +644,7 @@ BOT_RECORDING_SETTINGS_SCHEMA = {
         },
         "resolution": {
             "type": "string",
-            "description": "The resolution to use for the recording. The supported resolutions are '1080p' and '720p'. Defaults to '1080p'.",
+            "description": "The resolution to use for the recording. The supported resolutions are '1080p', '720p' and '480p'. Defaults to '1080p'.",
             "enum": RecordingResolutions.values,
         },
         "record_chat_messages_when_paused": {


### PR DESCRIPTION
## Summary
- add 480p to RecordingResolutions enum
- map 480p to dimensions 854x480
- update recording settings API schema description to list 480p as supported

## Validation
- python -m py_compile bots/models.py bots/serializers.py