### PR TITLE
fix: dismiss Gemini "Remember what was discussed" notes prompt

### DIFF
--- a/bots/google_meet_bot_adapter/google_meet_chromedriver_payload.js
+++ b/bots/google_meet_bot_adapter/google_meet_chromedriver_payload.js
@@ -212,6 +212,43 @@ class StyleManager {
             }
         }
 
+        // Check for Gemini "Remember what was discussed" notes prompt.
+        // Google shows this panel to signed-in accounts, prompting them to start
+        // Gemini note-taking. It overlays the top-left of the recording. Unlike
+        // the recording/transcription notifications above (which we accept), we
+        // need to dismiss this without clicking "Start taking notes".
+        // The prompt may be a modal dialog or a floating panel depending on the
+        // Meet version, so we check both.
+        const geminiNotesPrompt = [...document.querySelectorAll('[role="dialog"], [role="complementary"]')]
+            .find(el => el.textContent && el.textContent.includes('Remember what was discussed'));
+
+        if (geminiNotesPrompt) {
+            // Look for a close/dismiss button — NOT the "Start taking notes" action button
+            const closeBtn = geminiNotesPrompt.querySelector('button[aria-label="Close"]')
+                || geminiNotesPrompt.querySelector('button[aria-label="Dismiss"]')
+                || geminiNotesPrompt.querySelector('button[data-mdc-dialog-action="close"]')
+                || geminiNotesPrompt.querySelector('button[data-mdc-dialog-action="cancel"]');
+
+            let dismissAction, dismissMessage;
+            if (closeBtn) {
+                dismissAction = () => closeBtn.click();
+                dismissMessage = 'Dismissed Gemini notes prompt via close button';
+            } else {
+                // No close button found — send Escape to dismiss the overlay
+                dismissAction = () => document.dispatchEvent(new KeyboardEvent('keydown', {
+                    key: 'Escape', code: 'Escape', keyCode: 27, which: 27, bubbles: true, cancelable: true
+                }));
+                dismissMessage = 'Dismissed Gemini notes prompt via Escape key';
+            }
+
+            try {
+                dismissAction();
+                window.ws.sendJson({ type: 'UiInteraction', message: dismissMessage });
+            } catch (error) {
+                window.ws.sendJson({ type: 'Error', message: 'Error dismissing Gemini notes prompt' });
+            }
+        }
+
         // Check if bot has been removed from the meeting
         const removedFromMeetingElement = document.querySelector('.roSPhc');
         if (removedFromMeetingElement && (removedFromMeetingElement.textContent.includes('You\'ve been removed from the meeting') || removedFromMeetingElement.textContent.includes('Your host ended the meeting for everyone'))) {


### PR DESCRIPTION
Closes #650

## Problem

Google Meet now shows a Gemini notes prompt ("Remember what was discussed") to signed-in bot accounts. It overlays the top-left corner of the meeting view and appears in recordings.

The existing `checkNeededInteractions()` handler covers **post-activation** notifications ("Gemini is taking notes") but not this **pre-activation** prompt asking the user to start notes.

![image](https://github.com/user-attachments/assets/40630f3d-dc21-4633-8f54-139dd9720dba)

## Fix

Adds a new block in `checkNeededInteractions()` that:

1. **Detects** the prompt by searching for "Remember what was discussed" text — checks both `aria-modal` dialogs (reusing the existing `recordingDialog` query) and `[role="complementary"]` panels, since Google Meet renders this differently across versions
2. **Dismisses** without clicking "Start taking notes" — tries a close/dismiss button first (`aria-label="Close"`, `data-mdc-dialog-action="close"`, etc.), falls back to an Escape keypress

Runs every 5 seconds via the existing `checkNeededInteractions` interval, with `UiInteraction`/`Error` messages sent over the websocket for observability.

## Caveat

I haven't been able to inspect the live DOM of this prompt, so the dismiss strategy covers multiple selectors defensively. If someone can confirm the exact DOM structure (is it `aria-modal`? does it have a close button?), the selectors can be tightened.

## Test plan

- [ ] Join a Google Meet with a signed-in bot account that triggers the Gemini notes prompt
- [ ] Verify the prompt is dismissed within 5 seconds
- [ ] Verify "Start taking notes" is NOT clicked (Gemini notes should not activate)
- [ ] Verify the recording is clean (no overlay in top-left)
- [ ] Check websocket logs for `Dismissed Gemini notes prompt` message