### PR TITLE
isolate web bot recording audio

### DIFF
--- a/bots/bot_controller/bot_controller.py
+++ b/bots/bot_controller/bot_controller.py
@@ -186,6 +186,8 @@ class BotController:
     def get_google_meet_bot_adapter(self):
         from bots.google_meet_bot_adapter import GoogleMeetBotAdapter
 
+        browser_audio_environment = self.screen_and_audio_recorder.browser_audio_environment() if self.screen_and_audio_recorder else {}
+
         return GoogleMeetBotAdapter(
             display_name=self.bot_in_db.name,
             send_message_callback=self.on_message_from_adapter,
@@ -214,12 +216,14 @@ class BotController:
             google_meet_bot_login_is_available=self.google_meet_bot_login_is_available(),
             google_meet_bot_login_should_be_used=self.bot_in_db.google_meet_login_mode_is_always(),
             create_google_meet_bot_login_session_callback=self.create_google_meet_bot_login_session,
+            browser_audio_environment=browser_audio_environment,
         )
 
     def get_teams_bot_adapter(self):
         from bots.teams_bot_adapter import TeamsBotAdapter
 
         teams_bot_login_credentials = self.bot_in_db.project.credentials.filter(credential_type=Credentials.CredentialTypes.TEAMS_BOT_LOGIN).first()
+        browser_audio_environment = self.screen_and_audio_recorder.browser_audio_environment() if self.screen_and_audio_recorder else {}
 
         return TeamsBotAdapter(
             display_name=self.bot_in_db.name,
@@ -248,6 +252,7 @@ class BotController:
             record_participant_speech_start_stop_events=self.bot_in_db.record_participant_speech_start_stop_events(),
             disable_incoming_video=self.disable_incoming_video_for_web_bots(),
             modify_dom_for_video_recording=self.should_modify_dom_for_video_recording_for_web_bots(),
+            browser_audio_environment=browser_audio_environment,
         )
 
     def get_zoom_oauth_credentials_via_credentials_record(self):
@@ -292,6 +297,7 @@ class BotController:
         from bots.zoom_web_bot_adapter import ZoomWebBotAdapter
 
         zoom_tokens = self.get_zoom_tokens()
+        browser_audio_environment = self.screen_and_audio_recorder.browser_audio_environment() if self.screen_and_audio_recorder else {}
 
         return ZoomWebBotAdapter(
             display_name=self.bot_in_db.name,
@@ -321,6 +327,7 @@ class BotController:
             modify_dom_for_video_recording=self.should_modify_dom_for_video_recording_for_web_bots(),
             record_participant_speech_start_stop_events=self.bot_in_db.record_participant_speech_start_stop_events(),
             zoom_tokens=zoom_tokens,
+            browser_audio_environment=browser_audio_environment,
         )
 
     def get_zoom_bot_adapter(self):

--- a/bots/bot_controller/screen_and_audio_recorder.py
+++ b/bots/bot_controller/screen_and_audio_recorder.py
@@ -1,12 +1,13 @@
 import logging
 import os
 import subprocess
+import uuid
 
 logger = logging.getLogger(__name__)
 
 
 class ScreenAndAudioRecorder:
-    def __init__(self, file_location, recording_dimensions, audio_only):
+    def __init__(self, file_location, recording_dimensions, audio_only, audio_sink_name=None):
         self.file_location = file_location
         self.ffmpeg_proc = None
         # Screen will have buffer, we will crop to the recording dimensions
@@ -15,6 +16,74 @@ class ScreenAndAudioRecorder:
         self.audio_only = audio_only
         self.paused = False
         self.xterm_proc = None
+        self.audio_sink_name = audio_sink_name or f"attendee_bot_audio_{os.getpid()}_{uuid.uuid4().hex[:8]}"
+        self.audio_source_name = f"{self.audio_sink_name}.monitor"
+        self.audio_sink_module_id = None
+        self.isolated_audio_setup_attempted = False
+        self.isolated_audio_setup_succeeded = False
+
+    def setup_isolated_audio_sink(self):
+        if self.isolated_audio_setup_attempted:
+            return self.isolated_audio_setup_succeeded
+
+        self.isolated_audio_setup_attempted = True
+
+        try:
+            # Keep each web bot's Chrome audio on its own sink so simultaneous meetings do not mix in the final recording.
+            result = subprocess.run(
+                [
+                    "pactl",
+                    "load-module",
+                    "module-null-sink",
+                    f"sink_name={self.audio_sink_name}",
+                    "rate=48000",
+                    "channels=2",
+                    f"sink_properties=device.description={self.audio_sink_name}",
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            self.audio_sink_module_id = result.stdout.strip() or None
+            self.isolated_audio_setup_succeeded = True
+            logger.info(f"Created isolated PulseAudio sink {self.audio_sink_name} with module id {self.audio_sink_module_id}")
+        except Exception as e:
+            logger.warning(f"Could not create isolated PulseAudio sink {self.audio_sink_name}; falling back to default audio device: {e}")
+            self.isolated_audio_setup_succeeded = False
+
+        return self.isolated_audio_setup_succeeded
+
+    def browser_audio_environment(self):
+        if not self.setup_isolated_audio_sink():
+            return {}
+
+        return {"PULSE_SINK": self.audio_sink_name}
+
+    def ffmpeg_audio_input_args(self):
+        if self.setup_isolated_audio_sink():
+            return ["-f", "pulse", "-i", self.audio_source_name]
+
+        return ["-f", "alsa", "-i", "default"]
+
+    def audio_sink_for_mute(self):
+        if self.isolated_audio_setup_succeeded:
+            return self.audio_sink_name
+
+        return "@DEFAULT_SINK@"
+
+    def teardown_isolated_audio_sink(self):
+        if not self.audio_sink_module_id:
+            self.isolated_audio_setup_succeeded = False
+            return
+
+        try:
+            subprocess.run(["pactl", "unload-module", self.audio_sink_module_id], check=True, capture_output=True, text=True)
+            logger.info(f"Unloaded isolated PulseAudio sink {self.audio_sink_name} with module id {self.audio_sink_module_id}")
+        except Exception as e:
+            logger.warning(f"Failed to unload isolated PulseAudio sink {self.audio_sink_name}: {e}")
+        finally:
+            self.audio_sink_module_id = None
+            self.isolated_audio_setup_succeeded = False
 
     def start_recording(self, display_var):
         logger.info(f"Starting screen recorder for display {display_var} with dimensions {self.screen_dimensions} and file location {self.file_location}")
@@ -26,10 +95,7 @@ class ScreenAndAudioRecorder:
                 "-y",  # Overwrite output file without asking
                 "-thread_queue_size",
                 "4096",
-                "-f",
-                "alsa",  # Audio input format for Linux
-                "-i",
-                "default",  # Default audio input device
+                *self.ffmpeg_audio_input_args(),
                 "-c:a",
                 "libmp3lame",  # MP3 codec
                 "-b:a",
@@ -41,7 +107,7 @@ class ScreenAndAudioRecorder:
                 self.file_location,
             ]
         else:
-            ffmpeg_cmd = ["ffmpeg", "-y", "-thread_queue_size", "256", "-framerate", "30", "-video_size", f"{self.screen_dimensions[0]}x{self.screen_dimensions[1]}", "-f", "x11grab", "-draw_mouse", "0", "-probesize", "32", "-i", display_var, "-thread_queue_size", "4096", "-f", "alsa", "-i", "default", "-vf", f"crop={self.recording_dimensions[0]}:{self.recording_dimensions[1]}:10:10", "-c:v", "libx264", "-preset", "ultrafast", "-pix_fmt", "yuv420p", "-g", "30", "-c:a", "aac", "-strict", "experimental", "-b:a", "128k", self.file_location]
+            ffmpeg_cmd = ["ffmpeg", "-y", "-thread_queue_size", "256", "-framerate", "30", "-video_size", f"{self.screen_dimensions[0]}x{self.screen_dimensions[1]}", "-f", "x11grab", "-draw_mouse", "0", "-probesize", "32", "-i", display_var, "-thread_queue_size", "4096", *self.ffmpeg_audio_input_args(), "-vf", f"crop={self.recording_dimensions[0]}:{self.recording_dimensions[1]}:10:10", "-c:v", "libx264", "-preset", "ultrafast", "-pix_fmt", "yuv420p", "-g", "30", "-c:a", "aac", "-strict", "experimental", "-b:a", "128k", self.file_location]
 
         logger.info(f"Starting FFmpeg command: {' '.join(ffmpeg_cmd)}")
         self.ffmpeg_proc = subprocess.Popen(ffmpeg_cmd, stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT)
@@ -58,7 +124,7 @@ class ScreenAndAudioRecorder:
 
             self.xterm_proc = subprocess.Popen(["xterm", "-bg", "black", "-fg", "black", "-geometry", f"{sw}x{sh}+{x}+{y}", "-xrm", "*borderWidth:0", "-xrm", "*scrollBar:false"])
 
-            subprocess.run(["pactl", "set-sink-mute", "@DEFAULT_SINK@", "1"], check=True)
+            subprocess.run(["pactl", "set-sink-mute", self.audio_sink_for_mute(), "1"], check=True)
             self.paused = True
             return True
         except Exception as e:
@@ -74,7 +140,7 @@ class ScreenAndAudioRecorder:
             self.xterm_proc.terminate()
             self.xterm_proc.wait()
             self.xterm_proc = None
-            subprocess.run(["pactl", "set-sink-mute", "@DEFAULT_SINK@", "0"], check=True)
+            subprocess.run(["pactl", "set-sink-mute", self.audio_sink_for_mute(), "0"], check=True)
             self.paused = False
             return True
         except Exception as e:
@@ -98,35 +164,38 @@ class ScreenAndAudioRecorder:
         return f"{base}.seekable{ext}"
 
     def cleanup(self):
-        input_path = self.file_location
-
-        # If no input path at all, then we aren't trying to generate a file at all
-        if input_path is None:
-            return
-
-        # Check if input file exists
-        if not os.path.exists(input_path):
-            logger.info(f"Input file does not exist at {input_path}, creating empty file")
-            with open(input_path, "wb"):
-                pass  # Create empty file
-            return
-
-        # if audio only, we don't need to make it seekable
-        if self.audio_only:
-            return
-
-        # if input file is greater than 3 GB, we will skip seekability
-        if os.path.getsize(input_path) > 3 * 1024 * 1024 * 1024:
-            logger.info("Input file is greater than 3 GB, skipping seekability")
-            return
-
-        output_path = self.get_seekable_path(self.file_location)
-        # the file is seekable, so we don't need to make it seekable
         try:
-            self.make_file_seekable(input_path, output_path)
-        except Exception as e:
-            logger.error(f"Failed to make file seekable: {e}")
-            return
+            input_path = self.file_location
+
+            # If no input path at all, then we aren't trying to generate a file at all
+            if input_path is None:
+                return
+
+            # Check if input file exists
+            if not os.path.exists(input_path):
+                logger.info(f"Input file does not exist at {input_path}, creating empty file")
+                with open(input_path, "wb"):
+                    pass  # Create empty file
+                return
+
+            # if audio only, we don't need to make it seekable
+            if self.audio_only:
+                return
+
+            # if input file is greater than 3 GB, we will skip seekability
+            if os.path.getsize(input_path) > 3 * 1024 * 1024 * 1024:
+                logger.info("Input file is greater than 3 GB, skipping seekability")
+                return
+
+            output_path = self.get_seekable_path(self.file_location)
+            # the file is seekable, so we don't need to make it seekable
+            try:
+                self.make_file_seekable(input_path, output_path)
+            except Exception as e:
+                logger.error(f"Failed to make file seekable: {e}")
+                return
+        finally:
+            self.teardown_isolated_audio_sink()
 
     def make_file_seekable(self, input_path, tempfile_path):
         """Use ffmpeg to move the moov atom to the beginning of the file."""

--- a/bots/tests/test_screen_and_audio_recorder.py
+++ b/bots/tests/test_screen_and_audio_recorder.py
@@ -1,0 +1,82 @@
+import unittest
+from unittest.mock import Mock, call, patch
+
+from bots.bot_controller.screen_and_audio_recorder import ScreenAndAudioRecorder
+
+
+class TestScreenAndAudioRecorder(unittest.TestCase):
+    def create_recorder(self, audio_only=False):
+        return ScreenAndAudioRecorder(
+            file_location="/tmp/test-recording.mp4",
+            recording_dimensions=(1280, 720),
+            audio_only=audio_only,
+            audio_sink_name="attendee_test_sink",
+        )
+
+    @patch("bots.bot_controller.screen_and_audio_recorder.subprocess.run")
+    def test_browser_audio_environment_creates_isolated_pulseaudio_sink(self, mock_run):
+        mock_run.return_value = Mock(stdout="42\n")
+        recorder = self.create_recorder()
+
+        self.assertEqual(recorder.browser_audio_environment(), {"PULSE_SINK": "attendee_test_sink"})
+        mock_run.assert_called_once_with(
+            [
+                "pactl",
+                "load-module",
+                "module-null-sink",
+                "sink_name=attendee_test_sink",
+                "rate=48000",
+                "channels=2",
+                "sink_properties=device.description=attendee_test_sink",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+    @patch("bots.bot_controller.screen_and_audio_recorder.subprocess.Popen")
+    @patch("bots.bot_controller.screen_and_audio_recorder.subprocess.run")
+    def test_start_recording_uses_isolated_sink_monitor_when_available(self, mock_run, mock_popen):
+        mock_run.return_value = Mock(stdout="42\n")
+        recorder = self.create_recorder()
+        recorder.browser_audio_environment()
+
+        recorder.start_recording(":99")
+
+        ffmpeg_cmd = mock_popen.call_args.args[0]
+        self.assertIn("pulse", ffmpeg_cmd)
+        self.assertIn("attendee_test_sink.monitor", ffmpeg_cmd)
+
+    @patch("bots.bot_controller.screen_and_audio_recorder.subprocess.Popen")
+    @patch("bots.bot_controller.screen_and_audio_recorder.subprocess.run")
+    def test_start_recording_falls_back_to_alsa_default_when_sink_setup_fails(self, mock_run, mock_popen):
+        mock_run.side_effect = FileNotFoundError("pactl not found")
+        recorder = self.create_recorder()
+
+        recorder.start_recording(":99")
+
+        ffmpeg_cmd = mock_popen.call_args.args[0]
+        self.assertIn("alsa", ffmpeg_cmd)
+        self.assertIn("default", ffmpeg_cmd)
+
+    @patch("bots.bot_controller.screen_and_audio_recorder.subprocess.Popen")
+    @patch("bots.bot_controller.screen_and_audio_recorder.subprocess.run")
+    def test_pause_recording_mutes_only_isolated_sink(self, mock_run, mock_popen):
+        mock_run.return_value = Mock(stdout="42\n")
+        recorder = self.create_recorder()
+        recorder.browser_audio_environment()
+
+        self.assertTrue(recorder.pause_recording())
+
+        self.assertIn(call(["pactl", "set-sink-mute", "attendee_test_sink", "1"], check=True), mock_run.call_args_list)
+
+    @patch("bots.bot_controller.screen_and_audio_recorder.os.path.exists", return_value=True)
+    @patch("bots.bot_controller.screen_and_audio_recorder.subprocess.run")
+    def test_cleanup_unloads_isolated_sink_even_for_audio_only_recordings(self, mock_run, _mock_exists):
+        mock_run.return_value = Mock(stdout="42\n")
+        recorder = self.create_recorder(audio_only=True)
+        recorder.browser_audio_environment()
+
+        recorder.cleanup()
+
+        self.assertIn(call(["pactl", "unload-module", "42"], check=True, capture_output=True, text=True), mock_run.call_args_list)

--- a/bots/web_bot_adapter/web_bot_adapter.py
+++ b/bots/web_bot_adapter/web_bot_adapter.py
@@ -57,6 +57,7 @@ class WebBotAdapter(BotAdapter):
         record_chat_messages_when_paused: bool,
         disable_incoming_video: bool,
         record_participant_speech_start_stop_events: bool,
+        browser_audio_environment: dict[str, str] | None = None,
     ):
         self.display_name = display_name
         self.send_message_callback = send_message_callback
@@ -75,6 +76,7 @@ class WebBotAdapter(BotAdapter):
         self.record_chat_messages_when_paused = record_chat_messages_when_paused
         self.disable_incoming_video = disable_incoming_video
         self.record_participant_speech_start_stop_events = record_participant_speech_start_stop_events
+        self.browser_audio_environment = browser_audio_environment or {}
         self.meeting_url = meeting_url
 
         # This is an internal ID that comes from the platform. It is currently only used for MS Teams.
@@ -617,7 +619,10 @@ class WebBotAdapter(BotAdapter):
                 logger.warning(f"Error closing existing driver: {e}")
             self.driver = None
 
-        self.driver = webdriver.Chrome(options=options, service=Service(executable_path="/usr/local/bin/chromedriver"))
+        service_env = os.environ.copy()
+        service_env.update(self.browser_audio_environment)
+
+        self.driver = webdriver.Chrome(options=options, service=Service(executable_path="/usr/local/bin/chromedriver", env=service_env))
         logger.info(f"web driver server initialized at port {self.driver.service.port}")
 
         initial_data_code = f"window.initialData = {{websocketPort: {self.websocket_port}, videoFrameWidth: {self.video_frame_size[0]}, videoFrameHeight: {self.video_frame_size[1]}, botName: {json.dumps(self.display_name)}, addClickRipple: {'true' if self.should_create_debug_recording else 'false'}, recordingView: '{self.recording_view}', sendMixedAudio: {'true' if self.add_mixed_audio_chunk_callback else 'false'}, sendPerParticipantAudio: {'true' if self.add_audio_chunk_callback else 'false'}, perParticipantRealtimeVideoConfiguration: {json.dumps(self.per_participant_realtime_video_configuration.to_dict())}, sendPerParticipantVideo: {'true' if self.add_per_participant_video_frame_callback else 'false'}, collectCaptions: {'true' if self.upsert_caption_callback else 'false'}, recordParticipantSpeechStartStopEvents: {'true' if self.record_participant_speech_start_stop_events else 'false'}}}"


### PR DESCRIPTION
This fixes mixed audio in final meeting recordings when multiple web bots are running at the same time.

Root cause: the final recorder captured audio from the default ALSA/PulseAudio device. When simultaneous meetings shared the same PulseAudio sink/source, the final recording could include audio from other meetings even though the video was correct.

Changes:

Create a dedicated PulseAudio null sink per web bot recording.
Route Chrome audio for that bot to its dedicated sink via PULSE_SINK.
Make ffmpeg record from that sink’s monitor instead of the global default device.
Mute/unmute only the bot-specific sink during pause/resume.
Unload the dedicated sink during cleanup.
Add unit coverage for sink setup, ffmpeg input selection, fallback behavior, pause muting, and cleanup.