### PR TITLE
Fix Teams White Screen Issue

### DIFF
--- a/bots/teams_bot_adapter/teams_chromedriver_payload.js
+++ b/bots/teams_bot_adapter/teams_chromedriver_payload.js
@@ -510,8 +510,23 @@ class StyleManager {
         `;
         document.head.appendChild(style);
         this.frameStyleElement = style;
+
+        /* ── 3.  Break stacking contexts on ancestors ─────────────────── */
+        const centralElement = document.querySelector('[data-test-segment-type="central"]');
+        if (centralElement) {
+            let ancestor = centralElement.parentElement;
+            while (ancestor && ancestor !== document.body) {
+                ancestor.style.setProperty('transform', 'none', 'important');
+                ancestor.style.setProperty('will-change', 'auto', 'important');
+                ancestor.style.setProperty('filter', 'none', 'important');
+                ancestor.style.setProperty('contain', 'none', 'important');
+                ancestor.style.setProperty('isolation', 'auto', 'important');
+                ancestor.style.setProperty('perspective', 'none', 'important');
+                ancestor = ancestor.parentElement;
+            }
+        }
     
-        /* ── 3.  Keep the central element the right size ───────────────── */
+        /* ── 4.  Keep the central element the right size ───────────────── */
         const adjust = () => {
             this.adjustCentralElement?.();
             this.frameAdjustInterval = requestAnimationFrame(adjust);  // ← RAF loop


### PR DESCRIPTION
## Summary

- Resets CSS stacking-context-creating properties (`transform`, `will-change`, `filter`, `contain`, `isolation`, `perspective`) on all ancestors of the `[data-test-segment-type="central"]` element up to `document.body`.
- This prevents container styles from interfering with the fixed-position video frame overlay.

## Problem

Teams dynamically applies CSS properties on ancestor containers that create new stacking contexts. This causes the central video element (positioned with `position: fixed`) to render below other UI layers or get clipped, breaking the video frame layout.

## Solution

After injecting the frame styles, traverse up from the central element and force-reset all stacking-context-triggering properties with `!important`. This ensures the central element participates in the root stacking context as intended.