### PR TITLE
Add AssemblyAI prompt passthrough for transcription context biasing

### DIFF
--- a/bots/models.py
+++ b/bots/models.py
@@ -710,6 +710,9 @@ class TranscriptionSettings:
     def assemblyai_keyterms_prompt(self):
         return self._settings.get("assembly_ai", {}).get("keyterms_prompt", None)
 
+    def assemblyai_prompt(self):
+        return self._settings.get("assembly_ai", {}).get("prompt", None)
+
     def assemblyai_speech_model(self):
         return self._settings.get("assembly_ai", {}).get("speech_model", None)
 

--- a/bots/serializers.py
+++ b/bots/serializers.py
@@ -343,6 +343,7 @@ TRANSCRIPTION_SETTINGS_SCHEMA = {
                     "description": "Whether to automatically detect the spoken language.",
                 },
                 "keyterms_prompt": {"type": "array", "items": {"type": "string"}, "description": "List of words or phrases to boost in the transcript. Only supported for when using the 'slam-1' speech model. See AssemblyAI docs for details."},
+                "prompt": {"type": "string", "description": "Natural language prompt of up to 1500 words providing contextual information (e.g. meeting topic, participant names, domain terms) to bias transcription. Only supported for the 'universal-3-pro' speech model; ignored otherwise. See AssemblyAI docs for details."},
                 "speech_model": {"type": "string", "description": "The speech model to use for transcription. See AssemblyAI docs for details. This parameter is deprecated, use the speech_models param instead."},
                 "speech_models": {"type": "array", "items": {"type": "string"}, "uniqueItems": True, "description": "The speech models to use for transcription in order of preference. Defaults to ['universal-3-pro', 'universal-2']. See AssemblyAI docs for details."},
                 "speaker_labels": {"type": "boolean", "description": "Whether to enable AssemblyAI's ML-based diarization. Only needed if multiple people are speaking into a single microphone. Defaults to false."},

--- a/bots/tests/test_async_transcription.py
+++ b/bots/tests/test_async_transcription.py
@@ -561,6 +561,64 @@ class TestEndToEndAsyncTranscriptionAssemblyAI(AsyncTranscriptionTestCase):
         self.assertEqual(webhook_attempts.count(), 2)  # IN_PROGRESS and COMPLETE
 
     @mock.patch("bots.tasks.deliver_webhook_task.deliver_webhook")
+    @mock.patch("bots.transcription_utils.requests.delete")
+    @mock.patch("bots.transcription_utils.requests.get")
+    @mock.patch("bots.transcription_utils.requests.post")
+    @mock.patch("bots.transcription_utils.get_mp3_for_utterance_group")
+    def test_prompt_is_forwarded_to_transcribe_request(
+        self,
+        mock_get_mp3,
+        mock_post,
+        mock_get,
+        mock_delete,
+        mock_deliver_webhook,
+    ):
+        """The assembly_ai.prompt setting is forwarded to the transcribe request body."""
+        mock_deliver_webhook.return_value = None
+
+        self._create_audio_chunks(count=1, duration_ms=1000)
+
+        async_transcription = AsyncTranscription.objects.create(
+            recording=self.recording,
+            settings={"transcription_settings": {"assembly_ai": {"prompt": "Q3 planning for the Acme logistics platform; participants discuss the Helsinki rollout."}}},
+        )
+
+        mock_get_mp3.return_value = b"fake-mp3-data"
+
+        upload_response = mock.Mock()
+        upload_response.status_code = 200
+        upload_response.json.return_value = {"upload_url": "https://assemblyai.com/upload/123"}
+
+        transcribe_response = mock.Mock()
+        transcribe_response.status_code = 200
+        transcribe_response.json.return_value = {"id": "transcript-123"}
+
+        mock_post.side_effect = [upload_response, transcribe_response]
+
+        poll_response = mock.Mock()
+        poll_response.status_code = 200
+        poll_response.json.return_value = {
+            "status": "completed",
+            "text": "hello world test",
+            "language_code": "en",
+            "words": [{"text": "hello", "start": 0, "end": 500, "confidence": 0.99}],
+        }
+        mock_get.return_value = poll_response
+
+        delete_response = mock.Mock()
+        delete_response.status_code = 200
+        mock_delete.return_value = delete_response
+
+        process_async_transcription.delay(async_transcription.id)
+
+        # The second POST is the /transcript request carrying the settings.
+        transcribe_call = mock_post.call_args_list[1]
+        self.assertEqual(
+            transcribe_call.kwargs["json"]["prompt"],
+            "Q3 planning for the Acme logistics platform; participants discuss the Helsinki rollout.",
+        )
+
+    @mock.patch("bots.tasks.deliver_webhook_task.deliver_webhook")
     @mock.patch("bots.transcription_utils.requests.post")
     @mock.patch("bots.transcription_utils.get_mp3_for_utterance_group")
     def test_async_transcription_fails_with_invalid_credentials(

--- a/bots/transcription_utils.py
+++ b/bots/transcription_utils.py
@@ -308,6 +308,9 @@ def get_transcription_via_assemblyai_from_mp3(
     keyterms_prompt = transcription_settings.assemblyai_keyterms_prompt()
     if keyterms_prompt:
         data["keyterms_prompt"] = keyterms_prompt
+    prompt = transcription_settings.assemblyai_prompt()
+    if prompt:
+        data["prompt"] = prompt
     speech_model = transcription_settings.assemblyai_speech_model()
     if speech_model:
         if "speech_models" in data:


### PR DESCRIPTION
## What

Adds an optional `prompt` field to `transcription_settings.assembly_ai`, forwarded to AssemblyAI's pre-recorded `/transcript` request.

AssemblyAI's pre-recorded transcription endpoint accepts a natural-language [`prompt`](https://www.assemblyai.com/docs/api-reference/transcripts/submit) of up to 1500 words that biases transcription toward meeting-specific context (topic, participant names, domain vocabulary). It's supported on the **`universal-3-pro`** model — which is already Attendee's default speech model — and degrades gracefully (ignored if the request falls back to `universal-2`), so no model plumbing is needed.

This complements the existing `keyterms_prompt` (exact-term boosting) with free-text contextual framing, which AssemblyAI reports reduces WER on proper nouns and jargon.

## Changes

Mirrors the existing `keyterms_prompt` wiring exactly:

- `TranscriptionSettings.assemblyai_prompt()` accessor (`bots/models.py`)
- `prompt` string field on the `assembly_ai` create schema (`bots/serializers.py`)
- forwarded into the transcribe request body when set (`bots/transcription_utils.py`)
- test asserting `prompt` reaches the `/transcript` request payload (`bots/tests/test_async_transcription.py`)

## Usage

```json
{
  "transcription_settings": {
    "assembly_ai": {
      "prompt": "Q3 planning for the Acme logistics platform; participants discuss the Helsinki rollout."
    }
  }
}
```

## Notes

Purely additive and opt-in — no behavior change when `prompt` is unset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)