### PR TITLE
Fix Zoom Web mixed audio websocket forwarding

### DIFF
--- a/bots/tests/test_zoom_web_bot.py
+++ b/bots/tests/test_zoom_web_bot.py
@@ -3,8 +3,11 @@ import os
 import struct
 import threading
 import time
+from base64 import b64decode
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import numpy as np
 import requests
 from django.db import connection
 from django.test import TransactionTestCase, tag
@@ -13,6 +16,7 @@ from selenium.common.exceptions import NoSuchElementException
 from bots.bot_adapter import BotAdapter
 from bots.bot_controller.bot_controller import BotController
 from bots.models import Bot, BotEventManager, BotEventSubTypes, BotEventTypes, BotStates, Credentials, Organization, Project, Recording, RecordingTypes, TranscriptionProviders, TranscriptionTypes, WebhookDeliveryAttempt, WebhookSubscription, WebhookTriggerTypes, ZoomMeetingToZoomOAuthConnectionMapping, ZoomOAuthApp, ZoomOAuthConnection, ZoomOAuthConnectionStates
+from bots.zoom_web_bot_adapter.zoom_web_bot_adapter import ZoomWebBotAdapter
 
 
 # Helper functions for creating mocks
@@ -343,6 +347,99 @@ class TestZoomWebBot(TransactionTestCase):
         self.assertIsNotNone(last_event, "Expected a bot event to be created")
         self.assertEqual(last_event.event_type, BotEventTypes.COULD_NOT_JOIN)
         self.assertEqual(last_event.event_sub_type, BotEventSubTypes.COULD_NOT_JOIN_MEETING_BLOCKED_BY_CAPTCHA)
+
+    def test_zoom_web_payload_routes_mixed_audio_frames_to_websocket(self):
+        payload_path = Path(__file__).resolve().parents[1] / "zoom_web_bot_adapter" / "zoom_web_chromedriver_payload.js"
+        payload_code = payload_path.read_text()
+
+        self.assertIn(
+            "this.mixedAudioTrack = this.destination.stream.getAudioTracks()[0];",
+            payload_code,
+            "Zoom payload should capture the mixed audio track before trying to forward it",
+        )
+        self.assertIn(
+            "if (window.initialData.sendMixedAudio && this.mixedAudioTrack) {",
+            payload_code,
+            "Zoom payload should only start mixed-audio forwarding when enabled and a track exists",
+        )
+        self.assertIn(
+            "this.processMixedAudioTrack();",
+            payload_code,
+            "Zoom payload should start the mixed-audio processing loop",
+        )
+        self.assertIn(
+            "window.ws.sendMixedAudio(timestamp, audioData);",
+            payload_code,
+            "Zoom payload should forward mixed audio frames over the websocket",
+        )
+
+    def test_zoom_web_payload_initializes_mixed_audio_stream_when_track_arrives(self):
+        payload_path = Path(__file__).resolve().parents[1] / "zoom_web_bot_adapter" / "zoom_web_chromedriver_payload.js"
+        payload_code = payload_path.read_text()
+
+        block_start = payload_code.index("    addAudioTrack(track) {")
+        block_end = payload_code.index("    createStream()", block_start)
+        add_audio_track_block = payload_code[block_start:block_end]
+
+        self.assertIn(
+            "if (window.initialData.sendMixedAudio && !this.meetingAudioStream && !this.audioContext) {",
+            add_audio_track_block,
+            "Zoom payload should initialize mixed-audio streaming as soon as the first meeting track is added",
+        )
+        self.assertIn(
+            "this.getMeetingAudioStream();",
+            add_audio_track_block,
+            "Zoom payload should bootstrap the mixed-audio stream from addAudioTrack()",
+        )
+
+    def test_zoom_web_process_mixed_audio_frame_forwards_pcm_to_callback(self):
+        adapter = object.__new__(ZoomWebBotAdapter)
+        adapter.recording_paused = False
+        adapter.last_media_message_processed_time = None
+        adapter.last_audio_message_processed_time = None
+        adapter.add_mixed_audio_chunk_callback = MagicMock()
+        adapter.wants_any_video_frames_callback = None
+        adapter.send_frames = True
+
+        float_samples = np.array([0.25, -0.25, 0.0, 0.5], dtype=np.float32)
+        message = (3).to_bytes(4, byteorder="little") + float_samples.tobytes()
+
+        adapter.process_mixed_audio_frame(message)
+
+        adapter.add_mixed_audio_chunk_callback.assert_called_once()
+        forwarded_chunk = adapter.add_mixed_audio_chunk_callback.call_args.kwargs["chunk"]
+        forwarded_samples = np.frombuffer(forwarded_chunk, dtype=np.int16)
+        expected_samples = (float_samples * 32768.0).astype(np.int16)
+        np.testing.assert_array_equal(forwarded_samples, expected_samples)
+
+    @patch("time.time", return_value=1700000000.123)
+    def test_zoom_web_mixed_audio_callback_sends_realtime_audio_payload(self, mock_time):
+        self.bot.settings = {
+            "zoom_settings": {"sdk": "web"},
+            "recording_settings": {"format": "none"},
+            "websocket_settings": {"audio": {"url": "wss://example.com/audio-stream", "sample_rate": 16000}},
+        }
+        self.bot.save()
+
+        controller = BotController(self.bot.id)
+        controller.gstreamer_pipeline = None
+        controller.websocket_client_manager = MagicMock()
+
+        pcm_chunk = (np.array([0, 1200, -1200, 2400], dtype=np.int16)).tobytes()
+
+        controller.add_mixed_audio_chunk_callback(pcm_chunk)
+
+        controller.websocket_client_manager.send_mixed_audio.assert_called_once()
+        payload = controller.websocket_client_manager.send_mixed_audio.call_args.args[0]
+
+        self.assertEqual(payload["trigger"], "realtime_audio.mixed")
+        self.assertEqual(payload["bot_id"], self.bot.object_id)
+        self.assertEqual(payload["data"]["sample_rate"], 16000)
+        self.assertEqual(payload["data"]["timestamp_ms"], 1700000000123)
+
+        decoded_chunk = b64decode(payload["data"]["chunk"])
+        self.assertGreater(len(decoded_chunk), 0)
+        self.assertEqual(controller.pipeline_configuration.websocket_stream_audio, True)
 
     @patch("bots.zoom_oauth_connections_utils.requests.post")
     @patch("bots.web_bot_adapter.web_bot_adapter.Display")

--- a/bots/zoom_web_bot_adapter/zoom_web_chromedriver_payload.js
+++ b/bots/zoom_web_bot_adapter/zoom_web_chromedriver_payload.js
@@ -828,6 +828,7 @@ class MixedAudioStreamManager {
         this.audioContext = null;
         this.destination = null;
         this.seenTrackIds = new Set();
+        this.mixedAudioTrack = null;
     }
 
 
@@ -874,6 +875,12 @@ class MixedAudioStreamManager {
         else {
             this.audioTracksToBeAdded.push(track);
         }
+
+        // Mixed-audio forwarding depends on the stream being initialized after the
+        // first meeting track arrives. Zoom does not eagerly bootstrap this path.
+        if (window.initialData.sendMixedAudio && !this.meetingAudioStream && !this.audioContext) {
+            this.getMeetingAudioStream();
+        }
     }
 
     createStream() {
@@ -889,6 +896,13 @@ class MixedAudioStreamManager {
         // Create a source from the destination's stream so that it actually plays
         this.audioContext.createMediaStreamSource(this.destination.stream);
 
+        this.mixedAudioTrack = this.destination.stream.getAudioTracks()[0];
+
+        // Process and send mixed audio if enabled
+        if (window.initialData.sendMixedAudio && this.mixedAudioTrack) {
+            this.processMixedAudioTrack();
+        }
+
         window.ws?.sendJson({
             type: 'MeetingAudioStreamCreated',
             message: 'Meeting audio stream created',
@@ -898,6 +912,104 @@ class MixedAudioStreamManager {
     getMeetingAudioStream() {
         this.createStream();
         return this.meetingAudioStream;
+    }
+
+    async processMixedAudioTrack() {
+        try {
+            // Create processor to get raw audio frames from the mixed audio track
+            const processor = new MediaStreamTrackProcessor({ track: this.mixedAudioTrack });
+            const generator = new MediaStreamTrackGenerator({ kind: 'audio' });
+
+            // Get readable stream of audio frames
+            const readable = processor.readable;
+            const writable = generator.writable;
+
+            // Transform stream to intercept and send audio frames
+            const transformStream = new TransformStream({
+                async transform(frame, controller) {
+                    if (!frame) {
+                        return;
+                    }
+
+                    try {
+                        // Check if controller is still active
+                        if (controller.desiredSize === null) {
+                            frame.close();
+                            return;
+                        }
+
+                        // Copy the audio data
+                        const numChannels = frame.numberOfChannels;
+                        const numSamples = frame.numberOfFrames;
+                        const audioData = new Float32Array(numSamples);
+
+                        // Copy data from each channel
+                        // If multi-channel, average all channels together to create mono output
+                        if (numChannels > 1) {
+                            // Temporary buffer to hold each channel's data
+                            const channelData = new Float32Array(numSamples);
+
+                            // Sum all channels
+                            for (let channel = 0; channel < numChannels; channel++) {
+                                frame.copyTo(channelData, { planeIndex: channel });
+                                for (let i = 0; i < numSamples; i++) {
+                                    audioData[i] += channelData[i];
+                                }
+                            }
+
+                            // Average by dividing by number of channels
+                            for (let i = 0; i < numSamples; i++) {
+                                audioData[i] /= numChannels;
+                            }
+                        } else {
+                            // If already mono, just copy the data
+                            frame.copyTo(audioData, { planeIndex: 0 });
+                        }
+
+                        // Send mixed audio data via websocket
+                        const timestamp = performance.now();
+                        window.ws.sendMixedAudio(timestamp, audioData);
+
+                        // Pass through the original frame
+                        controller.enqueue(frame);
+                    } catch (error) {
+                        console.error('Error processing mixed audio frame:', error);
+                        frame.close();
+                    }
+                },
+                flush() {
+                    console.log('Mixed audio transform stream flush called');
+                }
+            });
+
+            // Create an abort controller for cleanup
+            const abortController = new AbortController();
+
+            try {
+                // Connect the streams
+                await readable
+                    .pipeThrough(transformStream)
+                    .pipeTo(writable, {
+                        signal: abortController.signal
+                    })
+                    .catch(error => {
+                        if (error.name !== 'AbortError') {
+                            console.error('Error in mixed audio pipe:', error);
+                        }
+                    });
+            } catch (error) {
+                console.error('Error setting up mixed audio processing:', error);
+            }
+
+            // Cleanup function
+            return () => {
+                abortController.abort();
+                processor?.close?.();
+                generator?.close?.();
+            };
+        } catch (error) {
+            console.error('Error in processMixedAudioTrack:', error);
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Fix the Zoom Web mixed-audio websocket path so it starts when the first meeting audio track arrives.

## Problem

Zoom Web bots could detect meeting audio tracks, but mixed audio was not reliably forwarded over the websocket path.

Observed behavior:
- captions could still work
- per-participant audio track detection could still work
- but `realtime_audio.mixed` would never start for Zoom Web

Fixes #881.

## Root cause

The Zoom Web payload defined the mixed-audio forwarding path, but it did not bootstrap the mixed-audio stream when the first meeting audio track arrived.

That meant the runtime could have frame-forwarding code present without ever initializing the mixed stream at the correct lifecycle point.

## Changes

- store the mixed audio track from the mixed destination stream
- start `processMixedAudioTrack()` when mixed audio is enabled and a mixed track exists
- bootstrap the mixed-audio stream from `addAudioTrack()` when the first meeting audio track arrives
- guard bootstrap so it only happens before the mixed stream has been initialized
- add regression coverage for:
  - payload mixed-audio websocket forwarding
  - mixed-audio stream initialization on first track arrival
  - Python-side mixed-audio frame decoding to callback
  - controller websocket payload emission for `realtime_audio.mixed`

## Test Plan

- [x] `python manage.py test bots.tests.test_zoom_web_bot.TestZoomWebBot.test_zoom_web_payload_routes_mixed_audio_frames_to_websocket bots.tests.test_zoom_web_bot.TestZoomWebBot.test_zoom_web_payload_initializes_mixed_audio_stream_when_track_arrives bots.tests.test_zoom_web_bot.TestZoomWebBot.test_zoom_web_process_mixed_audio_frame_forwards_pcm_to_callback bots.tests.test_zoom_web_bot.TestZoomWebBot.test_zoom_web_mixed_audio_callback_sends_realtime_audio_payload`
- [x] Manual validation against a real Zoom meeting with `zoom_settings.sdk=web`
- [x] Verified external websocket client received continuous `realtime_audio.mixed` messages
