### PR TITLE
feat: support AssemblyAI custom_spelling in transcription settings

### DIFF
--- a/bots/models.py
+++ b/bots/models.py
@@ -710,6 +710,9 @@ class TranscriptionSettings:
     def assemblyai_keyterms_prompt(self):
         return self._settings.get("assembly_ai", {}).get("keyterms_prompt", None)
 
+    def assemblyai_custom_spelling(self):
+        return self._settings.get("assembly_ai", {}).get("custom_spelling", None)
+
     def assemblyai_speech_model(self):
         return self._settings.get("assembly_ai", {}).get("speech_model", None)
 

--- a/bots/serializers.py
+++ b/bots/serializers.py
@@ -343,6 +343,7 @@ TRANSCRIPTION_SETTINGS_SCHEMA = {
                     "description": "Whether to automatically detect the spoken language.",
                 },
                 "keyterms_prompt": {"type": "array", "items": {"type": "string"}, "description": "List of words or phrases to boost in the transcript. Only supported for when using the 'slam-1' speech model. See AssemblyAI docs for details."},
+                "custom_spelling": {"type": "array", "items": {"type": "object", "properties": {"from": {"type": "array", "items": {"type": "string"}}, "to": {"type": "string"}}, "required": ["from", "to"], "additionalProperties": False}, "description": "List of {from: [...], to: ...} entries that deterministically replace known misspellings with the correct spelling at the engine level, preserving word-level timestamps. See AssemblyAI docs for details."},
                 "speech_model": {"type": "string", "description": "The speech model to use for transcription. See AssemblyAI docs for details. This parameter is deprecated, use the speech_models param instead."},
                 "speech_models": {"type": "array", "items": {"type": "string"}, "uniqueItems": True, "description": "The speech models to use for transcription in order of preference. Defaults to ['universal-3-pro', 'universal-2']. See AssemblyAI docs for details."},
                 "speaker_labels": {"type": "boolean", "description": "Whether to enable AssemblyAI's ML-based diarization. Only needed if multiple people are speaking into a single microphone. Defaults to false."},

--- a/bots/tests/test_process_utterance_task.py
+++ b/bots/tests/test_process_utterance_task.py
@@ -1439,6 +1439,93 @@ class AssemblyAIProviderTest(TransactionTestCase):
             self.assertEqual(data["speech_model"], "slam-1")
             self.assertNotIn("speech_models", data)
 
+    def test_custom_spelling_included(self):
+        """Test that custom_spelling is included in the AssemblyAI request if set in settings."""
+        custom_spelling = [
+            {"from": ["coober netties", "kubernets"], "to": "Kubernetes"},
+            {"from": ["macos"], "to": "macOS"},
+        ]
+        self.bot.settings = {
+            "transcription_settings": {
+                "assembly_ai": {
+                    "custom_spelling": custom_spelling,
+                }
+            }
+        }
+        self.bot.save()
+        with (
+            self._patch_creds(),
+            mock.patch("bots.tasks.process_utterance_task.pcm_to_mp3", return_value=b"mp3"),
+            mock.patch("bots.tasks.process_utterance_task.requests.post") as m_post,
+            mock.patch("bots.tasks.process_utterance_task.requests.get") as m_get,
+            mock.patch("bots.tasks.process_utterance_task.requests.delete") as m_delete,
+        ):
+            # 1. Mock upload response
+            upload_response = mock.Mock(status_code=200)
+            upload_response.json.return_value = {"upload_url": "https://cdn.assemblyai.com/upload/123"}
+
+            # 2. Mock transcript creation response
+            transcript_response = mock.Mock(status_code=200)
+            transcript_response.json.return_value = {"id": "transcript-abc"}
+
+            m_post.side_effect = [upload_response, transcript_response]
+
+            # 3. Mock polling responses
+            done_response = mock.Mock(status_code=200)
+            done_response.json.return_value = {
+                "status": "completed",
+                "text": "hello assembly",
+                "words": [],
+            }
+            m_get.return_value = done_response
+
+            # 4. Mock delete response
+            delete_response = mock.Mock(status_code=200)
+            m_delete.return_value = delete_response
+
+            transcript, failure = get_transcription_via_assemblyai(self.utterance)
+
+            self.assertIsNone(failure)
+            self.assertEqual(transcript["transcript"], "hello assembly")
+
+            # Check that the transcript creation request included custom_spelling
+            transcript_call = m_post.call_args_list[1]
+            _, kwargs = transcript_call
+            data = kwargs["json"]
+            self.assertIn("custom_spelling", data)
+            self.assertEqual(data["custom_spelling"], custom_spelling)
+
+    def test_custom_spelling_omitted_when_not_set(self):
+        """Test that custom_spelling is not included in the AssemblyAI request when unset."""
+        with (
+            self._patch_creds(),
+            mock.patch("bots.tasks.process_utterance_task.pcm_to_mp3", return_value=b"mp3"),
+            mock.patch("bots.tasks.process_utterance_task.requests.post") as m_post,
+            mock.patch("bots.tasks.process_utterance_task.requests.get") as m_get,
+            mock.patch("bots.tasks.process_utterance_task.requests.delete") as m_delete,
+        ):
+            upload_response = mock.Mock(status_code=200)
+            upload_response.json.return_value = {"upload_url": "https://cdn.assemblyai.com/upload/123"}
+            transcript_response = mock.Mock(status_code=200)
+            transcript_response.json.return_value = {"id": "transcript-abc"}
+            m_post.side_effect = [upload_response, transcript_response]
+
+            done_response = mock.Mock(status_code=200)
+            done_response.json.return_value = {"status": "completed", "text": "hello", "words": []}
+            m_get.return_value = done_response
+
+            delete_response = mock.Mock(status_code=200)
+            m_delete.return_value = delete_response
+
+            transcript, failure = get_transcription_via_assemblyai(self.utterance)
+
+            self.assertIsNone(failure)
+
+            transcript_call = m_post.call_args_list[1]
+            _, kwargs = transcript_call
+            data = kwargs["json"]
+            self.assertNotIn("custom_spelling", data)
+
     def test_default_speech_models(self):
         """Test that the default speech_models are included when no speech_model settings are configured."""
         with (

--- a/bots/transcription_utils.py
+++ b/bots/transcription_utils.py
@@ -321,6 +321,9 @@ def get_transcription_via_assemblyai_from_mp3(
     keyterms_prompt = transcription_settings.assemblyai_keyterms_prompt()
     if keyterms_prompt:
         data["keyterms_prompt"] = keyterms_prompt
+    custom_spelling = transcription_settings.assemblyai_custom_spelling()
+    if custom_spelling:
+        data["custom_spelling"] = custom_spelling
     speech_model = transcription_settings.assemblyai_speech_model()
     if speech_model:
         if "speech_models" in data:

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -2408,6 +2408,25 @@ components:
                   description: List of words or phrases to boost in the transcript.
                     Only supported for when using the 'slam-1' speech model. See AssemblyAI
                     docs for details.
+                custom_spelling:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      from:
+                        type: array
+                        items:
+                          type: string
+                      to:
+                        type: string
+                    required:
+                    - from
+                    - to
+                    additionalProperties: false
+                  description: 'List of {from: [...], to: ...} entries that deterministically
+                    replace known misspellings with the correct spelling at the engine
+                    level, preserving word-level timestamps. See AssemblyAI docs for
+                    details.'
                 speech_model:
                   type: string
                   description: The speech model to use for transcription. See AssemblyAI


### PR DESCRIPTION
## What

Adds support for AssemblyAI's `custom_spelling` parameter in `transcription_settings.assembly_ai`, mirroring the existing `keyterms_prompt` handling end to end.

`custom_spelling` lets callers deterministically map known misspellings to the correct spelling at the engine level (e.g. `{"from": ["coober netties"], "to": "Kubernetes"}`). Unlike post-transcription string replacement, engine-level correction preserves the word-level timestamps and confidence scores in AssemblyAI's `words` array — so subtitle/diarization alignment stays intact — and handles case normalization (e.g. `macos` → `macOS`) and multi-word phrases natively.

This is the natural companion to `keyterms_prompt`: keyterms biases recognition toward known vocabulary, while `custom_spelling` deterministically fixes known errors. Both are supported on AssemblyAI's async `/transcript` endpoint that Attendee already uses.

## Changes

- `bots/models.py` — `TranscriptionSettings.assemblyai_custom_spelling()` accessor
- `bots/transcription_utils.py` — forward `custom_spelling` into the AssemblyAI `/transcript` request body when set
- `bots/serializers.py` — request schema entry; `from` is an array of strings and `to` is a single string, matching [AssemblyAI's API shape](https://www.assemblyai.com/docs/speech-to-text/pre-recorded-audio/custom-spelling)
- `docs/openapi.yml` — API documentation for the new field
- `bots/tests/test_process_utterance_task.py` — tests for presence (payload includes `custom_spelling`) and omission (absent when unset)

Strictly additive and gated on the key being present, so existing behavior is unchanged.

## Testing

- `ruff check` and `ruff format --check` pass on all changed files
- New tests mirror the existing `test_keyterms_prompt_and_speech_model_included` structure (mocked upload/transcript/poll/delete), asserting the `/transcript` request body

> Note: I was unable to run the full Django test suite in my environment (needs Postgres/Redis), so I'd appreciate a maintainer running `bots/tests/test_process_utterance_task.py` in CI. The new tests follow the established pattern exactly.