### PR TITLE
fix: add configurable Docker network mode, CSRF trusted origins, and Dockerfile apt-get update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ RUN apt-get update  \
     libpq-dev
 
 # Install Chrome dependencies
-RUN apt-get install -y xvfb xauth x11-xkb-utils xfonts-100dpi xfonts-75dpi xfonts-scalable xfonts-cyrillic x11-apps libvulkan1 fonts-liberation xdg-utils wget
+RUN apt-get update && apt-get install -y xvfb xauth x11-xkb-utils xfonts-100dpi xfonts-75dpi xfonts-scalable xfonts-cyrillic x11-apps libvulkan1 fonts-liberation xdg-utils wget
 # Install a specific version of Chrome.
 RUN wget --progress=dot:giga --timeout=30 --tries=3 https://build-assets.attendee.dev/google-chrome/pool/main/g/google-chrome-stable/google-chrome-stable_134.0.6998.88-1_amd64.deb
 # Verify that the package is correct, since this is a mirror.

--- a/attendee/settings/production.py
+++ b/attendee/settings/production.py
@@ -41,6 +41,13 @@ else:
     SESSION_COOKIE_SECURE = False
     CSRF_COOKIE_SECURE = False
 
+# Trusted origins for CSRF (e.g. behind a reverse proxy like Traefik).
+# Defaults to https://<SITE_DOMAIN> when not explicitly set.
+CSRF_TRUSTED_ORIGINS = os.getenv(
+    "CSRF_TRUSTED_ORIGINS",
+    f"https://{os.getenv('SITE_DOMAIN', 'app.attendee.dev')}",
+).split(",")
+
 if os.getenv("DISABLE_EMAIL", "false") != "true":
     EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
     EMAIL_HOST = os.getenv("EMAIL_HOST", "smtp.mailgun.org")

--- a/bots/tasks/run_bot_in_ephemeral_container_task.py
+++ b/bots/tasks/run_bot_in_ephemeral_container_task.py
@@ -107,6 +107,11 @@ def run_bot_in_ephemeral_container(self, bot_id: int):
         host_code_path = os.getenv("BOT_HOST_CODE_PATH", "/opt/attendee")
         volumes = {host_code_path: {"bind": "/attendee", "mode": "rw"}}
 
+        # Network mode for the ephemeral container. Defaults to "host" (original behavior).
+        # Set BOT_CONTAINER_NETWORK to a Docker network name (e.g. the compose network) so that
+        # ephemeral bot containers join the same bridge network as the app/worker/postgres/redis
+        # and can resolve them by service name. This is required when running via docker-compose.
+        network_mode = os.getenv("BOT_CONTAINER_NETWORK", "host")
         # Launch ephemeral container
         container = client.containers.run(
             image=image,
@@ -120,7 +125,7 @@ def run_bot_in_ephemeral_container(self, bot_id: int):
             mem_limit=mem_limit,
             cpu_quota=cpu_quota,
             cpu_period=cpu_period,
-            network_mode="host",  # Same network mode as workers
+            network_mode=network_mode,
             security_opt=["seccomp=unconfined"],  # Same config as workers
             # Container will automatically stop after max_execution_seconds thanks to timeout in command
         )


### PR DESCRIPTION
## Changes

- **`bots/tasks/run_bot_in_ephemeral_container_task.py`**: Make the ephemeral container network mode configurable via `BOT_CONTAINER_NETWORK` env var (defaults to `host` for original behavior). Allows ephemeral bot containers to join the compose bridge network and resolve services by name.
- **`attendee/settings/production.py`**: Add `CSRF_TRUSTED_ORIGINS` setting, defaulting to `https://<SITE_DOMAIN>`. Needed when running behind a reverse proxy like Traefik.
- **`Dockerfile`**: Add `apt-get update` before the Chrome dependencies install to avoid stale-cache failures.

## Files changed
- `Dockerfile`
- `attendee/settings/production.py`
- `bots/tasks/run_bot_in_ephemeral_container_task.py`