### PR TITLE
fix: prevent empty recording file from overwriting completed recording (#587)

### DIFF
--- a/bots/bot_controller/bot_controller.py
+++ b/bots/bot_controller/bot_controller.py
@@ -645,15 +645,19 @@ class BotController:
             logger.info("Telling websocket client manager to cleanup...")
             self.websocket_client_manager.cleanup()
 
-        if self.get_recording_file_location():
+        recording_file_location = self.get_recording_file_location()
+        if recording_file_location and not self.local_recording_file_has_content(recording_file_location):
+            # Skip upload of a missing/empty file so we don't overwrite an existing recording (issue #587).
+            logger.warning(f"Recording file at {recording_file_location} is missing or empty, skipping upload to avoid overwriting an existing recording")
+        elif recording_file_location:
             self.upload_recording_to_external_media_storage_if_enabled()
 
             logger.info("Telling file uploader to upload recording file...")
             file_uploader = self.get_file_uploader()
-            file_uploader.upload_file(self.get_recording_file_location())
+            file_uploader.upload_file(recording_file_location)
             file_uploader.wait_for_upload()
             logger.info("File uploader finished uploading file")
-            file_uploader.delete_file(self.get_recording_file_location())
+            file_uploader.delete_file(recording_file_location)
             logger.info("File uploader deleted file from local filesystem")
             self.recording_file_saved(file_uploader.filename)
 
@@ -748,6 +752,13 @@ class BotController:
             return None
         else:
             return os.path.join(self.get_recording_storage_directory(), self.get_recording_filename())
+
+    def local_recording_file_has_content(self, recording_file_location):
+        """True only if the local recording file exists and is non-empty (issue #587)."""
+        try:
+            return os.path.getsize(recording_file_location) > 0
+        except OSError:
+            return False
 
     def get_recording_storage_directory(self):
         if self.bot_in_db.reserve_additional_storage():

--- a/bots/bot_controller/screen_and_audio_recorder.py
+++ b/bots/bot_controller/screen_and_audio_recorder.py
@@ -104,11 +104,9 @@ class ScreenAndAudioRecorder:
         if input_path is None:
             return
 
-        # Check if input file exists
+        # Don't create an empty placeholder here: it would get uploaded and overwrite an existing recording (issue #587).
         if not os.path.exists(input_path):
-            logger.info(f"Input file does not exist at {input_path}, creating empty file")
-            with open(input_path, "wb"):
-                pass  # Create empty file
+            logger.info(f"Input file does not exist at {input_path}, skipping seekability processing")
             return
 
         # if audio only, we don't need to make it seekable

--- a/bots/tests/test_recording_upload_guard.py
+++ b/bots/tests/test_recording_upload_guard.py
@@ -1,0 +1,58 @@
+import os
+import tempfile
+
+from django.test import TestCase
+
+from bots.bot_controller.bot_controller import BotController
+from bots.bot_controller.screen_and_audio_recorder import ScreenAndAudioRecorder
+
+
+class ScreenAndAudioRecorderCleanupTestCase(TestCase):
+    """Issue #587: cleanup() must not create an empty placeholder file."""
+
+    def test_cleanup_does_not_create_empty_file_when_missing(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            missing_path = os.path.join(tmp, "bot-rec.mp4")
+            recorder = ScreenAndAudioRecorder(file_location=missing_path, recording_dimensions=(1280, 720), audio_only=False)
+
+            recorder.cleanup()
+
+            self.assertFalse(os.path.exists(missing_path), "cleanup() must not create an empty placeholder file")
+
+    def test_cleanup_leaves_existing_audio_file_untouched(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "bot-rec.mp3")
+            with open(path, "wb") as f:
+                f.write(b"real audio bytes")
+
+            recorder = ScreenAndAudioRecorder(file_location=path, recording_dimensions=(1280, 720), audio_only=True)
+            recorder.cleanup()
+
+            with open(path, "rb") as f:
+                self.assertEqual(f.read(), b"real audio bytes")
+
+
+class LocalRecordingFileHasContentTestCase(TestCase):
+    """Issue #587 upload guard: only a non-empty existing file is uploadable."""
+
+    def _controller(self):
+        # Skip the heavy __init__; the method only touches os.
+        return BotController.__new__(BotController)
+
+    def test_missing_file_is_not_uploadable(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self.assertFalse(self._controller().local_recording_file_has_content(os.path.join(tmp, "nope.mp4")))
+
+    def test_empty_file_is_not_uploadable(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "empty.mp4")
+            with open(path, "wb"):
+                pass
+            self.assertFalse(self._controller().local_recording_file_has_content(path))
+
+    def test_non_empty_file_is_uploadable(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "real.mp4")
+            with open(path, "wb") as f:
+                f.write(b"\x00\x01\x02")
+            self.assertTrue(self._controller().local_recording_file_has_content(path))


### PR DESCRIPTION
## Summary
Fixes #587. When a `run_bot` task ran cleanup for a bot whose recording had already been uploaded and its local file deleted, the recorder created a zero-byte placeholder file that the uploader then pushed to S3/MinIO, overwriting the existing recording with empty content — permanent data loss.

## Changes
- `ScreenAndAudioRecorder.cleanup()` no longer creates an empty placeholder file when the recording file is missing; it just skips seekability processing.
- `BotController.cleanup()` skips the upload entirely when the local recording file is missing or zero bytes, so an existing stored recording is never overwritten with empty content (defense in depth, covers the gstreamer path too).

## Scope / follow-up
This PR stops the data loss regardless of what triggered the redundant cleanup. The underlying question of *why* a `run_bot` task runs a second time for an already-ENDED bot (the trigger noted in the issue) will be investigated separately and addressed in a follow-up PR if necessary.

## Testing
- New `bots/tests/test_recording_upload_guard.py` — 5 regression tests, all passing.
- Existing `test_cleanup.py` (21 tests) still passing.
- `ruff check` and `ruff format --check` clean.

## Docs
No API or user-facing behavior change — no `docs/openapi.yml` / README updates needed.