### PR TITLE
fix: prevent redelivered run_bot tasks from re-running finished bots (#587)

### DIFF
--- a/attendee/celery.py
+++ b/attendee/celery.py
@@ -28,12 +28,19 @@ if sslCertRequirements is not None:
 else:
     app = Celery("attendee")
 
-# Currently the only use case for CELERY_BROKER_TRANSPORT_OPTIONS is to enable support for Redis Cluster hash
+# The Redis broker redelivers unacked tasks after visibility_timeout (default 3600s). With acks_late, run_bot stays
+# unacked for the whole meeting, so this must exceed the longest bot runtime or a duplicate run_bot task gets
+# delivered mid-meeting (issue #587).
+broker_transport_options = {"visibility_timeout": int(os.getenv("CELERY_BROKER_VISIBILITY_TIMEOUT_SECONDS", 21600))}
+
+# One use case for CELERY_BROKER_TRANSPORT_OPTIONS is to enable support for Redis Cluster hash
 # tags. This is mainly to prevent CROSSSLOT errors when using Redis Cluster (https://github.com/celery/celery/issues/8276#issuecomment-3714489309)
 # For this case set CELERY_BROKER_TRANSPORT_OPTIONS='{"global_keyprefix":"{celeryattendee}:","fanout_prefix":true,"fanout_patterns":true}'
 
 if os.getenv("CELERY_BROKER_TRANSPORT_OPTIONS"):
-    app.conf.update(broker_transport_options=json.loads(os.getenv("CELERY_BROKER_TRANSPORT_OPTIONS")))
+    broker_transport_options.update(json.loads(os.getenv("CELERY_BROKER_TRANSPORT_OPTIONS")))
+
+app.conf.update(broker_transport_options=broker_transport_options)
 
 # Load configuration from Django settings
 app.config_from_object("django.conf:settings", namespace="CELERY")

--- a/bots/tasks/run_bot_task.py
+++ b/bots/tasks/run_bot_task.py
@@ -6,12 +6,18 @@ from celery import shared_task
 from celery.signals import worker_shutting_down
 
 from bots.bot_controller import BotController
+from bots.models import Bot, BotStates
 
 logger = logging.getLogger(__name__)
 
 
 @shared_task(bind=True, soft_time_limit=3600)
 def run_bot(self, bot_id):
+    bot = Bot.objects.get(id=bot_id)
+    # Guard against broker redelivery: re-running a finished bot risks clobbering its recording (issue #587).
+    if bot.state in BotStates.post_meeting_states():
+        logger.warning(f"Bot {bot_id} is already in post-meeting state {BotStates.state_to_api_code(bot.state)}, skipping run_bot")
+        return
     logger.info(f"Running bot {bot_id}")
     bot_controller = BotController(bot_id)
     bot_controller.run()

--- a/bots/tests/test_run_bot_task.py
+++ b/bots/tests/test_run_bot_task.py
@@ -1,0 +1,33 @@
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from accounts.models import Organization
+from bots.models import Bot, BotStates, Project
+from bots.tasks.run_bot_task import run_bot
+
+
+class RunBotTaskGuardTestCase(TestCase):
+    """Issue #587: a redelivered run_bot task must not run a bot that already finished."""
+
+    def setUp(self):
+        self.organization = Organization.objects.create(name="Test Org")
+        self.project = Project.objects.create(organization=self.organization, name="Test Project")
+        self.bot = Bot.objects.create(project=self.project, name="Test Bot", meeting_url="https://meet.google.com/abc-defg-hij", state=BotStates.READY)
+
+    def _run_task(self):
+        with patch("bots.tasks.run_bot_task.BotController") as mock_controller:
+            run_bot.apply(args=[self.bot.id])
+        return mock_controller
+
+    def test_skips_bot_in_post_meeting_state(self):
+        for state in BotStates.post_meeting_states():
+            Bot.objects.filter(pk=self.bot.pk).update(state=state)
+            mock_controller = self._run_task()
+            mock_controller.assert_not_called()
+
+    def test_runs_bot_not_in_post_meeting_state(self):
+        Bot.objects.filter(pk=self.bot.pk).update(state=BotStates.READY)
+        mock_controller = self._run_task()
+        mock_controller.assert_called_once_with(self.bot.id)
+        mock_controller.return_value.run.assert_called_once()


### PR DESCRIPTION
## Summary
Follow-up to #897, addressing the *trigger* behind #587: why a `run_bot` task runs a second time for an already-ENDED bot.

## Root cause
The production settings profiles set `CELERY_TASK_ACKS_LATE = True` with `CELERY_TASK_REJECT_ON_WORKER_LOST = True`. Since `run_bot` runs for the entire meeting, its message stays unacked the whole time and gets redelivered in two scenarios:

1. **Worker lost/restarted mid-task** — the broker requeues the unacked message; a worker then picks up `run_bot` for a bot that has meanwhile reached `ENDED`. This matches the reporter's "restart → recording wiped" sequence.
2. **Redis `visibility_timeout` expiry** — the Redis broker's default is 3600s and was not overridden, so any bot running longer than ~1 hour gets a duplicate, *concurrent* `run_bot` delivery even without a restart.

Nothing made `run_bot` idempotent, so the redundant run created a `BotController` that never recorded and, on shutdown, uploaded an empty file over the completed recording (guarded separately in #897).

## Changes
- `run_bot` aborts immediately if the bot is already in a post-meeting state (`BotStates.post_meeting_states()`), as suggested in the issue discussion.
- Default the Redis broker `visibility_timeout` to 21600s, env-overridable via `CELERY_BROKER_VISIBILITY_TIMEOUT_SECONDS`, merged with the existing `CELERY_BROKER_TRANSPORT_OPTIONS` env support (env keys win).

The state guard handles redelivery for finished bots; the visibility_timeout bump prevents duplicate concurrent deliveries for still-running bots.

## Trade-off: crash-recovery latency for short tasks
`visibility_timeout` is broker-wide, so raising it to 6h also delays the redelivery safety net for short tasks (`deliver_webhook`, `process_utterance`, etc.): if a worker dies *hard* (OOM-kill/node loss, no graceful shutdown), its unacked messages now wait up to 6h instead of 1h before another worker restores them. In practice the blast radius is small: `reject_on_worker_lost=True` requeues immediately in the common child-process-death case (visibility_timeout not involved), and `prefetch_multiplier=1` means a dead worker holds at most ~1 extra message. All ETA/countdown usage in the codebase is ≤64s, far below either value — raising the timeout actually moves further from the classic Redis+Celery duplicate-ETA-execution failure mode. Operators who prefer the old behavior can set `CELERY_BROKER_VISIBILITY_TIMEOUT_SECONDS=3600`.

## Testing
- New `bots/tests/test_run_bot_task.py` — skips all post-meeting states, runs otherwise; passing.
- Verified `broker_transport_options` resolves correctly with and without `CELERY_BROKER_TRANSPORT_OPTIONS` set.
- Existing `test_launch_scheduled_bot_task` + `test_throttling` still passing.
- `ruff check` and `ruff format --check` clean.

## Docs
No API change — no `docs/openapi.yml` updates needed.
