### PR TITLE
Add scheduler heartbeat file for liveness probing

### DIFF
--- a/bots/management/commands/run_scheduler.py
+++ b/bots/management/commands/run_scheduler.py
@@ -25,6 +25,10 @@ log = logging.getLogger(__name__)
 
 CALENDAR_SYNC_THRESHOLD_HOURS = 24  # The longest a calendar can go without having been synced
 
+# Heartbeat file the scheduler rewrites each cycle so a liveness probe can
+# restart the pod if the loop stalls (a process-liveness check wouldn't catch it).
+SCHEDULER_HEARTBEAT_FILE = os.getenv("SCHEDULER_HEARTBEAT_FILE", "/tmp/scheduler_heartbeat")
+
 
 class Command(BaseCommand):
     help = "Runs celery tasks for scheduled bots."
@@ -60,6 +64,14 @@ class Command(BaseCommand):
             log.exception("Failed to get Celery queue %s size", queue_name)
             self._redis_client = None  # Reset connection on failure
 
+    def _write_heartbeat(self):
+        """Rewrite the heartbeat file so a liveness probe can detect a stalled loop."""
+        try:
+            with open(SCHEDULER_HEARTBEAT_FILE, "w") as f:
+                f.write(str(time.time()))
+        except Exception:
+            log.warning("Failed to write scheduler heartbeat file", exc_info=True)
+
     def _log_celery_queue_sizes(self):
         try:
             # Get all the celery queue names from the CELERY_TASK_ROUTES setting
@@ -76,6 +88,8 @@ class Command(BaseCommand):
 
         interval = opts["interval"]
         log.info("Scheduler daemon started, polling every %s seconds", interval)
+        # Write an initial heartbeat so the liveness probe passes during startup.
+        self._write_heartbeat()
 
         while self._keep_running:
             began = time.monotonic()
@@ -91,6 +105,10 @@ class Command(BaseCommand):
             finally:
                 # Close stale connections so the loop never inherits a dead socket
                 connection.close()
+
+            # A completed cycle refreshes the heartbeat. If the loop stalls mid-cycle,
+            # this stops updating and the liveness probe restarts the pod.
+            self._write_heartbeat()
 
             # Sleep the *remainder* of the interval, even if work took time T
             elapsed = time.monotonic() - began

--- a/bots/tests/test_run_scheduler_command.py
+++ b/bots/tests/test_run_scheduler_command.py
@@ -1,6 +1,8 @@
 import base64
 import json
+import os
 import signal
+import tempfile
 from unittest.mock import MagicMock, patch
 
 from django.test import TestCase
@@ -66,6 +68,28 @@ class RunSchedulerCommandTestCase(TestCase):
 
         # Verify the shutdown flag was set
         self.assertFalse(command._keep_running)
+
+    def test_write_heartbeat_creates_file_with_timestamp(self):
+        """_write_heartbeat writes the current time to the heartbeat file."""
+        command = Command()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            heartbeat_path = os.path.join(tmpdir, "scheduler_heartbeat")
+            with patch("bots.management.commands.run_scheduler.SCHEDULER_HEARTBEAT_FILE", heartbeat_path):
+                with patch("bots.management.commands.run_scheduler.time.time", return_value=1234567890.0):
+                    command._write_heartbeat()
+
+                self.assertTrue(os.path.exists(heartbeat_path))
+                with open(heartbeat_path) as f:
+                    self.assertEqual(f.read(), "1234567890.0")
+
+    def test_write_heartbeat_swallows_errors(self):
+        """A failed heartbeat write must never raise, so it can't crash the scheduler loop."""
+        command = Command()
+
+        with patch("builtins.open", side_effect=OSError("read-only file system")):
+            # Should not raise
+            command._write_heartbeat()
 
     def test_run_scheduled_bots_ignores_bots_outside_time_threshold(self):
         """Test that bots outside the 5-minute time window are ignored"""


### PR DESCRIPTION
## What

Have `run_scheduler` write a heartbeat file at the end of every polling cycle (and once at startup), so a Kubernetes liveness probe can detect when the loop has stalled.

## Why

`run_scheduler` runs as a single long-lived process. Its loop makes Redis and DB calls that can block indefinitely (no socket/statement timeouts), so if one of those calls hangs, the process stays **alive but frozen** — it stops launching scheduled bots without crashing or raising. A plain process-liveness check can't tell this apart from a healthy process, so nothing restarts it and scheduled bots silently stop launching until someone redeploys.

Writing a heartbeat file each cycle turns this into something an exec liveness probe can catch: if the file goes stale, the loop is stuck and the pod can be restarted automatically.

## Changes

- `SCHEDULER_HEARTBEAT_FILE` env var (default `/tmp/scheduler_heartbeat`).
- `_write_heartbeat()` rewrites the file with the current timestamp; failures are logged and swallowed so heartbeat I/O can never take the scheduler down.
- Called once at startup and at the end of each cycle (after the `finally` cleanup), so a mid-cycle hang leaves the file stale rather than refreshing it.
- Two unit tests covering the write and the error-swallowing path.

This change is inert on its own — it only writes a file. Wiring up the liveness probe that reads it is done in deployment config.
