### PR TITLE
fix: Connect late-arriving Google Meet audio tracks to the mixed-audio graph

### DIFF
--- a/bots/google_meet_bot_adapter/google_meet_chromedriver_payload.js
+++ b/bots/google_meet_bot_adapter/google_meet_chromedriver_payload.js
@@ -232,6 +232,7 @@ class StyleManager {
 
         this.audioContext = null;
         this.audioTracks = [];
+        this.mixDestination = null;
         this.silenceThreshold = 0.5;
         this.silenceCheckInterval = null;
         this.memoryUsageCheckInterval = null;
@@ -243,6 +244,15 @@ class StyleManager {
 
     addAudioTrack(audioTrack) {
         this.audioTracks.push(audioTrack);
+        // If startSilenceDetection() already ran, patch the new track into the existing
+        // mix. Without this, every track Meet negotiates after the mix is built is
+        // collected here and never heard. Tracks added before it exists are picked up
+        // out of this.audioTracks when the mix is built.
+        if (this.audioContext && this.mixDestination) {
+            const source = this.audioContext.createMediaStreamSource(new MediaStream([audioTrack]));
+            source.connect(this.mixDestination);
+            this.audioSources.push(source);
+        }
     }
 
     checkAudioActivity() {
@@ -330,6 +340,7 @@ class StyleManager {
  
          // Create a destination node
          const destination = this.audioContext.createMediaStreamDestination();
+         this.mixDestination = destination;
  
          // Connect all sources to the destination
          this.audioSources.forEach(source => {


### PR DESCRIPTION
## Problem

`StyleManager` builds the Google Meet meeting-audio mix exactly once, in `startSilenceDetection()` — it snapshots `this.audioTracks` into source nodes and connects those to a `MediaStreamDestination`:

```js
this.audioSources = this.audioTracks.map(track => {
    const mediaStream = new MediaStream([track]);
    return this.audioContext.createMediaStreamSource(mediaStream);
});
const destination = this.audioContext.createMediaStreamDestination();
this.audioSources.forEach(source => source.connect(destination));
```

`addAudioTrack()` keeps collecting every audio track the peer connection negotiates afterwards, but only pushes to the array:

```js
addAudioTrack(audioTrack) {
    this.audioTracks.push(audioTrack);
}
```

Nothing ever connects those later tracks to `destination`. The mix carries only the tracks that happened to exist at graph-build time, and is entirely silent when that set was empty.

The ordering makes this the common case rather than an edge case. `addAudioTrack()` is called from the `track` event on the meeting peer connection, whenever Meet negotiates one. `startSilenceDetection()` runs from `start()`, which runs from `enableMediaSending()`. So any participant whose audio track is negotiated after the bot starts sending media is inaudible in the mix — as is anything Meet re-negotiates while the bot is in the call.

## Impact

Three consumers read that one graph, so they all observe the same silence:

- `getMeetingAudioStream()` — the stream `shared_chromedriver_payload.js` adds to the webpage-streamer peer connection, which becomes the voice agent page's `getUserMedia` microphone. A voice agent in Google Meet hears nothing and never responds.
- `processMixedAudioTrack()` — the `sendMixedAudio` websocket output, taken from `destination.stream.getAudioTracks()[0]`.
- `checkAudioActivity()` — the silence detector, whose analyser is fed by `createMediaStreamSource(destination.stream)`. A meeting with real audio can read as silent.

## Fix

`MixedAudioStreamManager` in the Teams adapter already solves this — it patches a late track straight into the live destination and only queues one when the graph doesn't exist yet:

```js
// If start() already ran, patch the new track into the existing mix.
if (this.audioContext && this.destination) {
    const source = this.audioContext.createMediaStreamSource(mediaStream);
    source.connect(this.destination);
    this.sourceNodes.push(source);
}
else {
    this.audioTracksToBeAdded.push(track);
}
```

This applies the same idiom to Google Meet: hold the destination on `this.mixDestination`, and have `addAudioTrack()` connect into it when the graph is already live. Tracks that arrive before it exists are unaffected — they are still picked up out of `this.audioTracks` when the mix is built. Adding a source to a `MediaStreamDestination` after the fact is reflected in the already-handed-out `destination.stream`, so no consumer needs to re-fetch anything.

+11 lines, no behavior change on the pre-existing path.

## Testing

There is no JS harness for the injected payloads, so this was verified by running it: with the patch, a Google Meet voice agent that previously received a flat near-silent signal receives the participants' audio and responds normally. Before the patch, the mixed stream measured at effectively the noise floor for the whole call regardless of who was speaking.

`node --check` passes on the modified payload.