### PR TITLE
Add MinIO service for running the full stack locally

### DIFF
--- a/attendee/settings/base.py
+++ b/attendee/settings/base.py
@@ -283,6 +283,10 @@ else:
             "secret_key": os.getenv("AWS_SECRET_ACCESS_KEY"),
         },
     }
+    # S3-compatible endpoints like MinIO/LocalStack don't support virtual-hosted-style
+    # requests (bucket-as-subdomain), so fall back to path-style addressing for them.
+    if os.getenv("AWS_ENDPOINT_URL"):
+        DEFAULT_STORAGE_BACKEND["OPTIONS"]["addressing_style"] = "path"
     # Deep copy the DEFAULT_STORAGE_BACKEND
     RECORDING_STORAGE_BACKEND = copy.deepcopy(DEFAULT_STORAGE_BACKEND)
     RECORDING_STORAGE_BACKEND["OPTIONS"]["bucket_name"] = AWS_RECORDING_STORAGE_BUCKET_NAME

--- a/attendee/settings/base.py
+++ b/attendee/settings/base.py
@@ -283,9 +283,11 @@ else:
             "secret_key": os.getenv("AWS_SECRET_ACCESS_KEY"),
         },
     }
-    # S3-compatible endpoints like MinIO/LocalStack don't support virtual-hosted-style
-    # requests (bucket-as-subdomain), so fall back to path-style addressing for them.
-    if os.getenv("AWS_ENDPOINT_URL"):
+    # Some S3-compatible endpoints (MinIO, LocalStack) require path-style addressing,
+    # while others (e.g. Google Cloud Storage's S3-compatible API) require virtual-hosted
+    # style. We can't infer which is needed just from AWS_ENDPOINT_URL being set, so this
+    # is an explicit opt-in.
+    if os.getenv("AWS_S3_USE_PATH_STYLE_ADDRESSING", "false") == "true":
         DEFAULT_STORAGE_BACKEND["OPTIONS"]["addressing_style"] = "path"
     # Deep copy the DEFAULT_STORAGE_BACKEND
     RECORDING_STORAGE_BACKEND = copy.deepcopy(DEFAULT_STORAGE_BACKEND)

--- a/bots/bot_controller/bot_controller.py
+++ b/bots/bot_controller/bot_controller.py
@@ -633,6 +633,7 @@ class BotController:
             bucket=settings.AWS_RECORDING_STORAGE_BUCKET_NAME,
             filename=self.get_recording_filename(),
             endpoint_url=settings.RECORDING_STORAGE_BACKEND.get("OPTIONS").get("endpoint_url"),
+            use_path_style_addressing=settings.RECORDING_STORAGE_BACKEND.get("OPTIONS").get("addressing_style") == "path",
         )
 
     def cleanup(self):

--- a/bots/bot_controller/s3_file_uploader.py
+++ b/bots/bot_controller/s3_file_uploader.py
@@ -10,15 +10,16 @@ logger.setLevel(logging.INFO)
 
 
 class S3FileUploader:
-    def __init__(self, bucket, filename, endpoint_url=None, region_name=None, access_key_id=None, access_key_secret=None):
+    def __init__(self, bucket, filename, endpoint_url=None, region_name=None, access_key_id=None, access_key_secret=None, use_path_style_addressing=False):
         """Initialize the S3FileUploader with an S3 bucket name.
 
         Args:
             bucket (str): The name of the S3 bucket to upload to
             filename (str): The name of the to be stored file
         """
-        # S3-compatible endpoints like MinIO/LocalStack require path-style addressing.
-        config = Config(s3={"addressing_style": "path"}) if endpoint_url else None
+        # Path-style addressing is required by some S3-compatible endpoints (MinIO,
+        # LocalStack) but breaks others, so callers must opt in explicitly.
+        config = Config(s3={"addressing_style": "path"}) if use_path_style_addressing else None
         self.s3_client = boto3.client("s3", endpoint_url=endpoint_url, region_name=region_name, aws_access_key_id=access_key_id, aws_secret_access_key=access_key_secret, config=config)
         self.bucket = bucket
         self.filename = filename

--- a/bots/bot_controller/s3_file_uploader.py
+++ b/bots/bot_controller/s3_file_uploader.py
@@ -3,6 +3,7 @@ import threading
 from pathlib import Path
 
 import boto3
+from botocore.config import Config
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -16,7 +17,9 @@ class S3FileUploader:
             bucket (str): The name of the S3 bucket to upload to
             filename (str): The name of the to be stored file
         """
-        self.s3_client = boto3.client("s3", endpoint_url=endpoint_url, region_name=region_name, aws_access_key_id=access_key_id, aws_secret_access_key=access_key_secret)
+        # S3-compatible endpoints like MinIO/LocalStack require path-style addressing.
+        config = Config(s3={"addressing_style": "path"}) if endpoint_url else None
+        self.s3_client = boto3.client("s3", endpoint_url=endpoint_url, region_name=region_name, aws_access_key_id=access_key_id, aws_secret_access_key=access_key_secret, config=config)
         self.bucket = bucket
         self.filename = filename
         self._upload_thread = None

--- a/bots/bot_controller/streaming_uploader.py
+++ b/bots/bot_controller/streaming_uploader.py
@@ -13,8 +13,9 @@ logger = logging.getLogger(__name__)
 class StreamingUploader:
     def __init__(self, bucket, key, chunk_size=5242880):  # 5MB chunks
         endpoint_url = os.getenv("AWS_ENDPOINT_URL")
-        # S3-compatible endpoints like MinIO/LocalStack require path-style addressing.
-        config = Config(s3={"addressing_style": "path"}) if endpoint_url else None
+        # Path-style addressing is required by some S3-compatible endpoints (MinIO,
+        # LocalStack) but breaks others, so this is an explicit opt-in.
+        config = Config(s3={"addressing_style": "path"}) if os.getenv("AWS_S3_USE_PATH_STYLE_ADDRESSING", "false") == "true" else None
         self.s3_client = boto3.client("s3", endpoint_url=endpoint_url, config=config)
         self.bucket = bucket
         self.key = key

--- a/bots/bot_controller/streaming_uploader.py
+++ b/bots/bot_controller/streaming_uploader.py
@@ -5,13 +5,17 @@ from io import BytesIO
 from queue import Queue
 
 import boto3
+from botocore.config import Config
 
 logger = logging.getLogger(__name__)
 
 
 class StreamingUploader:
     def __init__(self, bucket, key, chunk_size=5242880):  # 5MB chunks
-        self.s3_client = boto3.client("s3", endpoint_url=os.getenv("AWS_ENDPOINT_URL"))
+        endpoint_url = os.getenv("AWS_ENDPOINT_URL")
+        # S3-compatible endpoints like MinIO/LocalStack require path-style addressing.
+        config = Config(s3={"addressing_style": "path"}) if endpoint_url else None
+        self.s3_client = boto3.client("s3", endpoint_url=endpoint_url, config=config)
         self.bucket = bucket
         self.key = key
         self.chunk_size = chunk_size

--- a/dev.docker-compose.yaml
+++ b/dev.docker-compose.yaml
@@ -116,6 +116,7 @@ services:
       /bin/sh -c "
       until mc alias set local http://minio:9000 minioadmin minioadmin; do sleep 1; done;
       mc mb --ignore-existing local/attendee-recordings;
+      mc mb --ignore-existing local/minutesiq-dev;
       "
 
 networks:

--- a/dev.docker-compose.yaml
+++ b/dev.docker-compose.yaml
@@ -11,9 +11,6 @@ services:
       - DJANGO_SETTINGS_MODULE=attendee.settings.development
       - ENABLE_CHROME_SANDBOX=false
     command: "celery -A attendee worker -l INFO"
-    depends_on:
-      minio-createbuckets:
-        condition: service_completed_successfully
 
   attendee-scheduler-local:
     build: ./
@@ -27,9 +24,6 @@ services:
       - DJANGO_SETTINGS_MODULE=attendee.settings.development
     command: "python manage.py run_scheduler"
     entrypoint: []
-    depends_on:
-      minio-createbuckets:
-        condition: service_completed_successfully
 
   attendee-app-local:
     build: ./
@@ -45,9 +39,6 @@ services:
       - DJANGO_SETTINGS_MODULE=attendee.settings.development
     command: python manage.py runserver 0.0.0.0:8000
     entrypoint: []
-    depends_on:
-      minio-createbuckets:
-        condition: service_completed_successfully
 
   attendee-webpage-streamer-local:
     build: ./
@@ -89,6 +80,7 @@ services:
     volumes:
       - redis:/data/redis
 
+  # Optional local S3-compatible storage — see README.md for setup.
   minio:
     image: minio/minio:latest
     command: server /data --console-address ":9001"
@@ -103,9 +95,9 @@ services:
     networks:
       - attendee_network
     restart: unless-stopped
+    profiles:
+      - minio
 
-  # One-shot job that creates the recording bucket on startup so the app
-  # never has to worry about bucket provisioning.
   minio-createbuckets:
     image: minio/mc:latest
     networks:
@@ -116,8 +108,9 @@ services:
       /bin/sh -c "
       until mc alias set local http://minio:9000 minioadmin minioadmin; do sleep 1; done;
       mc mb --ignore-existing local/attendee-recordings;
-      mc mb --ignore-existing local/minutesiq-dev;
       "
+    profiles:
+      - minio
 
 networks:
   attendee_network:

--- a/dev.docker-compose.yaml
+++ b/dev.docker-compose.yaml
@@ -11,6 +11,9 @@ services:
       - DJANGO_SETTINGS_MODULE=attendee.settings.development
       - ENABLE_CHROME_SANDBOX=false
     command: "celery -A attendee worker -l INFO"
+    depends_on:
+      minio-createbuckets:
+        condition: service_completed_successfully
 
   attendee-scheduler-local:
     build: ./
@@ -24,6 +27,9 @@ services:
       - DJANGO_SETTINGS_MODULE=attendee.settings.development
     command: "python manage.py run_scheduler"
     entrypoint: []
+    depends_on:
+      minio-createbuckets:
+        condition: service_completed_successfully
 
   attendee-app-local:
     build: ./
@@ -39,6 +45,9 @@ services:
       - DJANGO_SETTINGS_MODULE=attendee.settings.development
     command: python manage.py runserver 0.0.0.0:8000
     entrypoint: []
+    depends_on:
+      minio-createbuckets:
+        condition: service_completed_successfully
 
   attendee-webpage-streamer-local:
     build: ./
@@ -80,6 +89,35 @@ services:
     volumes:
       - redis:/data/redis
 
+  minio:
+    image: minio/minio:latest
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadmin
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    volumes:
+      - minio:/data
+    networks:
+      - attendee_network
+    restart: unless-stopped
+
+  # One-shot job that creates the recording bucket on startup so the app
+  # never has to worry about bucket provisioning.
+  minio-createbuckets:
+    image: minio/mc:latest
+    networks:
+      - attendee_network
+    depends_on:
+      - minio
+    entrypoint: >
+      /bin/sh -c "
+      until mc alias set local http://minio:9000 minioadmin minioadmin; do sleep 1; done;
+      mc mb --ignore-existing local/attendee-recordings;
+      "
+
 networks:
   attendee_network:
     driver: bridge
@@ -87,3 +125,4 @@ networks:
 volumes:
   postgres:
   redis:
+  minio:

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -54,10 +54,28 @@ This document lists all supported environment variables for the Attendee applica
 | `AWS_ACCESS_KEY_ID` | String | **Required** | AWS IAM access key ID for S3 authentication. |
 | `AWS_SECRET_ACCESS_KEY` | String | **Required** | AWS IAM secret access key for S3 authentication. |
 | `AWS_DEFAULT_REGION` | String | `us-east-1` | Default AWS region for S3 operations. |
-| `AWS_ENDPOINT_URL` | String | (None) | Custom S3-compatible endpoint URL (e.g., for MinIO or LocalStack). |
+| `AWS_ENDPOINT_URL` | String | (None) | Custom S3-compatible endpoint URL (e.g., for MinIO or LocalStack). When set, path-style addressing is used automatically instead of virtual-hosted-style. |
 | `AWS_RECORDING_STORAGE_BUCKET_NAME` | String | **Required** | S3 bucket name for storing meeting recordings. |
 | `AWS_AUDIO_CHUNK_STORAGE_BUCKET_NAME` | String | (Uses recording bucket) | S3 bucket name for storing audio chunks. Falls back to `AWS_RECORDING_STORAGE_BUCKET_NAME` if not set. |
 | `USE_IRSA_FOR_S3_STORAGE` | Boolean | `false` | Use IRSA (IAM Roles for Service Accounts) for S3 authentication in EKS. Set to `true` when running on Kubernetes with IRSA. |
+
+### Running against MinIO locally
+
+`dev.docker-compose.yaml` includes a `minio` service plus a `minio-createbuckets` one-shot job that
+creates the `attendee-recordings` bucket on startup. `.env` is preconfigured to point at it
+(`AWS_ENDPOINT_URL=http://minio:9000`, `AWS_ACCESS_KEY_ID=minioadmin`, `AWS_SECRET_ACCESS_KEY=minioadmin`).
+
+Recording download links are generated as presigned URLs against `AWS_ENDPOINT_URL`, so the `minio`
+hostname needs to resolve both from inside the Docker network (it does, via Compose's built-in DNS)
+and from your host machine (for opening those links in a browser or via `curl`). Add this line to
+your machine's hosts file (`/etc/hosts` on macOS/Linux, `C:\Windows\System32\drivers\etc\hosts` on Windows):
+
+```
+127.0.0.1 minio
+```
+
+The MinIO console is available at http://localhost:9001 (login `minioadmin` / `minioadmin`) if you want
+to browse uploaded recordings directly.
 
 ### Azure Blob Storage Configuration
 

--- a/init_env.py
+++ b/init_env.py
@@ -16,10 +16,11 @@ def main():
 
     print(f"CREDENTIALS_ENCRYPTION_KEY={credentials_key}")
     print(f"DJANGO_SECRET_KEY={django_key}")
-    print("AWS_RECORDING_STORAGE_BUCKET_NAME=")
-    print("AWS_ACCESS_KEY_ID=")
-    print("AWS_SECRET_ACCESS_KEY=")
+    print("AWS_RECORDING_STORAGE_BUCKET_NAME=attendee-recordings")
+    print("AWS_ACCESS_KEY_ID=minioadmin")
+    print("AWS_SECRET_ACCESS_KEY=minioadmin")
     print("AWS_DEFAULT_REGION=us-east-1")
+    print("AWS_ENDPOINT_URL=http://minio:9000")
 
 
 if __name__ == "__main__":

--- a/init_env.py
+++ b/init_env.py
@@ -16,11 +16,10 @@ def main():
 
     print(f"CREDENTIALS_ENCRYPTION_KEY={credentials_key}")
     print(f"DJANGO_SECRET_KEY={django_key}")
-    print("AWS_RECORDING_STORAGE_BUCKET_NAME=attendee-recordings")
-    print("AWS_ACCESS_KEY_ID=minioadmin")
-    print("AWS_SECRET_ACCESS_KEY=minioadmin")
+    print("AWS_RECORDING_STORAGE_BUCKET_NAME=")
+    print("AWS_ACCESS_KEY_ID=")
+    print("AWS_SECRET_ACCESS_KEY=")
     print("AWS_DEFAULT_REGION=us-east-1")
-    print("AWS_ENDPOINT_URL=http://minio:9000")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Wires an S3-compatible MinIO container into dev.docker-compose.yaml with automatic bucket creation, and fixes path-style addressing (required by MinIO/LocalStack) in both the django-storages config and the raw boto3 upload clients used for recordings.