### PR TITLE
feat: add an option to pin a Google Meet message so messages can reach late joiners

### DIFF
--- a/bots/bot_controller/bot_controller.py
+++ b/bots/bot_controller/bot_controller.py
@@ -1145,15 +1145,43 @@ class BotController:
         chat_message_requests = self.bot_in_db.chat_message_requests.filter(state=BotChatMessageRequestStates.ENQUEUED)
         for chat_message_request in chat_message_requests:
             try:
-                self.adapter.send_chat_message(
+                delivery_result = self.adapter.send_chat_message(
                     text=chat_message_request.message,
                     to_user_uuid=chat_message_request.to_user_uuid,
                     pin=chat_message_request.additional_data.get("pin", False),
                 )
-                BotChatMessageRequestManager.set_chat_message_request_sent(chat_message_request)
+                if not isinstance(delivery_result, dict):
+                    delivery_result = {"sent": True}
+                if delivery_result.get("sent"):
+                    if delivery_result.get("pinned") is False:
+                        logger.warning(
+                            "Chat message request %s was sent but not pinned: %s",
+                            chat_message_request.id,
+                            delivery_result,
+                        )
+                    BotChatMessageRequestManager.set_chat_message_request_sent(
+                        chat_message_request,
+                        delivery_data=delivery_result,
+                    )
+                else:
+                    logger.warning(
+                        "Chat message request %s was not sent: %s",
+                        chat_message_request.id,
+                        delivery_result,
+                    )
+                    BotChatMessageRequestManager.set_chat_message_request_failed(
+                        chat_message_request,
+                        failure_data=delivery_result,
+                    )
             except Exception as e:
                 logger.warning(f"Error sending chat message request {chat_message_request.id}: {e}")
-                BotChatMessageRequestManager.set_chat_message_request_failed(chat_message_request)
+                BotChatMessageRequestManager.set_chat_message_request_failed(
+                    chat_message_request,
+                    failure_data={
+                        "failure_stage": "adapter_exception",
+                        "failure_reason": type(e).__name__,
+                    },
+                )
 
     def take_action_based_on_voice_agent_settings_in_db(self):
         if self.bot_in_db.should_launch_webpage_streamer():

--- a/bots/bot_controller/bot_controller.py
+++ b/bots/bot_controller/bot_controller.py
@@ -1144,8 +1144,16 @@ class BotController:
 
         chat_message_requests = self.bot_in_db.chat_message_requests.filter(state=BotChatMessageRequestStates.ENQUEUED)
         for chat_message_request in chat_message_requests:
-            self.adapter.send_chat_message(text=chat_message_request.message, to_user_uuid=chat_message_request.to_user_uuid)
-            BotChatMessageRequestManager.set_chat_message_request_sent(chat_message_request)
+            try:
+                self.adapter.send_chat_message(
+                    text=chat_message_request.message,
+                    to_user_uuid=chat_message_request.to_user_uuid,
+                    pin=chat_message_request.additional_data.get("pin", False),
+                )
+                BotChatMessageRequestManager.set_chat_message_request_sent(chat_message_request)
+            except Exception as e:
+                logger.warning(f"Error sending chat message request {chat_message_request.id}: {e}")
+                BotChatMessageRequestManager.set_chat_message_request_failed(chat_message_request)
 
     def take_action_based_on_voice_agent_settings_in_db(self):
         if self.bot_in_db.should_launch_webpage_streamer():

--- a/bots/bots_api_utils.py
+++ b/bots/bots_api_utils.py
@@ -107,6 +107,7 @@ def create_bot_chat_message_request(bot, chat_message_data):
             to_user_uuid=to_user_uuid,
             to=chat_message_data["to"],
             message=chat_message_data["message"],
+            additional_data={"pin": True} if chat_message_data.get("pin", False) else {},
         )
     except ValidationError as e:
         raise e

--- a/bots/google_meet_bot_adapter/google_meet_bot_adapter.py
+++ b/bots/google_meet_bot_adapter/google_meet_bot_adapter.py
@@ -36,6 +36,7 @@ class GoogleMeetBotAdapter(WebBotAdapter, GoogleMeetUIMethods):
         self.number_of_times_blocked_by_google = 0
         self.number_of_times_mocap_sequence_not_available = 0
         self.ui_interaction_mode = ui_interaction_mode
+        self.pending_chat_message_pin = None
 
     def should_retry_joining_meeting_that_requires_login_by_logging_in(self):
         # If we don't have the ability to login, we can't retry
@@ -93,7 +94,27 @@ class GoogleMeetBotAdapter(WebBotAdapter, GoogleMeetUIMethods):
 
         pin_result = self._pin_chat_message(result.get("message_id"), text)
         result.update(pin_result)
+        active_host_present = any(
+            participant.get("active") and participant.get("isHost")
+            for participant in getattr(self, "participants_info", {}).values()
+        )
+        if pin_result.get("failure_reason") == "pin_action_not_found" and not active_host_present:
+            self.pending_chat_message_pin = {
+                "message_id": result.get("message_id"),
+                "text": text,
+            }
         return result
+
+    def handle_participant_update(self, user):
+        super().handle_participant_update(user)
+        if not user.get("active") or not user.get("isHost") or not self.pending_chat_message_pin:
+            return
+
+        pending_pin = self.pending_chat_message_pin
+        self.pending_chat_message_pin = None
+        pin_result = self._pin_chat_message(pending_pin["message_id"], pending_pin["text"])
+        if not pin_result.get("pinned"):
+            logger.warning("Deferred chat message pin failed after host joined: %s", pin_result)
 
     def _pin_chat_message(self, message_id, text, timeout_seconds=20):
         if not message_id:

--- a/bots/google_meet_bot_adapter/google_meet_bot_adapter.py
+++ b/bots/google_meet_bot_adapter/google_meet_bot_adapter.py
@@ -1,6 +1,10 @@
 import json
 import logging
+import time
 from typing import Callable
+
+from selenium.common.exceptions import StaleElementReferenceException
+from selenium.webdriver.common.by import By
 
 from bots.google_meet_bot_adapter.google_meet_ui_methods import (
     GoogleMeetUIMethods,
@@ -68,18 +72,156 @@ class GoogleMeetBotAdapter(WebBotAdapter, GoogleMeetUIMethods):
         result = self.driver.execute_async_script(
             """
             const done = arguments[arguments.length - 1];
-            Promise.resolve(window?.sendChatMessage(arguments[0], arguments[1]))
+            Promise.resolve(window?.sendChatMessage(arguments[0]))
                 .then(done)
                 .catch((error) => {
                     console.error("Error sending Google Meet chat message", error);
-                    done(false);
+                    done({sent: false, failure_stage: "send", failure_reason: String(error)});
                 });
             """,
             text,
-            pin,
         )
-        if not result:
-            raise RuntimeError("Google Meet chat message could not be sent or pinned")
+        if not isinstance(result, dict) or not result.get("sent"):
+            return result or {
+                "sent": False,
+                "failure_stage": "send",
+                "failure_reason": "invalid_browser_result",
+            }
+
+        if not pin:
+            return result
+
+        pin_result = self._pin_chat_message(result.get("message_id"), text)
+        result.update(pin_result)
+        return result
+
+    def _pin_chat_message(self, message_id, text, timeout_seconds=20):
+        if not message_id:
+            return {
+                "pinned": False,
+                "failure_stage": "pin_target",
+                "failure_reason": "message_id_missing",
+            }
+
+        deadline = time.monotonic() + timeout_seconds
+        last_failure_reason = "pin_button_not_found"
+        while time.monotonic() < deadline:
+            try:
+                messages = self.driver.find_elements(By.CSS_SELECTOR, "[data-message-id]")
+                message = next((candidate for candidate in messages if candidate.get_attribute("data-message-id") == message_id), None)
+                if message is None:
+                    message = self.driver.execute_script(
+                        """
+                        const text = arguments[0];
+                        const matchingMessages = Array.from(document.querySelectorAll('[data-message-id]'))
+                            .filter(candidate => Array.from(candidate.querySelectorAll('div'))
+                                .some(descendant => descendant.textContent?.trim() === text));
+                        return matchingMessages.at(-1) || null;
+                        """,
+                        text,
+                    )
+                if message is None:
+                    last_failure_reason = "message_element_not_found"
+                    time.sleep(0.25)
+                    continue
+                self.driver.execute_script(
+                    """
+                    arguments[0].scrollIntoView({block: 'center'});
+                    for (const eventType of ['mouseenter', 'mouseover', 'mousemove']) {
+                        arguments[0].dispatchEvent(new MouseEvent(eventType, {bubbles: true, view: window}));
+                    }
+                    """,
+                    message,
+                )
+
+                unpin_buttons = message.find_elements(By.CSS_SELECTOR, '[aria-label="Unpin"], [aria-label="Unpin message"], [aria-label="Unpin from board"]')
+                if unpin_buttons:
+                    return {"pinned": True, "message_id": message_id}
+
+                pin_buttons = message.find_elements(By.CSS_SELECTOR, '[aria-label="Pin"], [aria-label="Pin message"]')
+                if pin_buttons:
+                    self.driver.execute_script("arguments[0].click();", pin_buttons[-1])
+                    self._confirm_chat_message_pin()
+                    last_failure_reason = "pin_not_verified"
+                else:
+                    board_pin_result = self._pin_chat_message_to_board(message)
+                    if board_pin_result == "pinned":
+                        return {
+                            "pinned": True,
+                            "message_id": message_id,
+                            "pin_method": "board",
+                        }
+                    if board_pin_result == "clicked":
+                        last_failure_reason = "board_pin_not_verified"
+                    else:
+                        last_failure_reason = "pin_action_not_found"
+            except StaleElementReferenceException:
+                last_failure_reason = "stale_message_element"
+            except Exception as exc:
+                last_failure_reason = type(exc).__name__
+            time.sleep(0.25)
+
+        return {
+            "pinned": False,
+            "message_id": message_id,
+            "failure_stage": "pin",
+            "failure_reason": last_failure_reason,
+        }
+
+    def _pin_chat_message_to_board(self, message):
+        more_actions = message.find_elements(
+            By.CSS_SELECTOR,
+            '[aria-label="More actions"], [aria-label="More options"], [aria-label*="More actions"]',
+        )
+        if not more_actions:
+            more_actions = [
+                button
+                for button in self.driver.find_elements(By.CSS_SELECTOR, 'button[aria-label^="More options for "]')
+                if button.is_displayed()
+            ]
+        if not more_actions:
+            return "not_found"
+
+        self.driver.execute_script("arguments[0].click();", more_actions[-1])
+        menu_items = []
+        menu_deadline = time.monotonic() + 2
+        while time.monotonic() < menu_deadline and not menu_items:
+            menu_items = [item for item in self.driver.find_elements(By.CSS_SELECTOR, '[role="menuitem"]') if item.is_displayed()]
+            if not menu_items:
+                time.sleep(0.1)
+        unpin_from_board = next(
+            (
+                item
+                for item in reversed(menu_items)
+                if item.text.strip() in {"Unpin", "Unpin from board"} or item.get_attribute("aria-label") == "Unpin from board"
+            ),
+            None,
+        )
+        if unpin_from_board is not None:
+            return "pinned"
+
+        pin_to_board = next(
+            (
+                item
+                for item in reversed(menu_items)
+                if item.text.strip() == "Pin to board" or item.get_attribute("aria-label") == "Pin to board"
+            ),
+            None,
+        )
+        if pin_to_board is None:
+            return "not_found"
+
+        self.driver.execute_script("arguments[0].click();", pin_to_board)
+        return "clicked"
+
+    def _confirm_chat_message_pin(self):
+        dialogs = self.driver.find_elements(By.CSS_SELECTOR, '[role="dialog"]')
+        for dialog in reversed(dialogs):
+            buttons = dialog.find_elements(By.CSS_SELECTOR, "button")
+            matching_buttons = [button for button in buttons if button.text.strip() in {"Pin", "Pin this message"}]
+            if matching_buttons:
+                matching_buttons[-1].click()
+                return
 
     def update_closed_captions_language(self, language):
         if self.google_meet_closed_captions_language == language:

--- a/bots/google_meet_bot_adapter/google_meet_bot_adapter.py
+++ b/bots/google_meet_bot_adapter/google_meet_bot_adapter.py
@@ -64,8 +64,22 @@ class GoogleMeetBotAdapter(WebBotAdapter, GoogleMeetUIMethods):
         logger.info(f"send_video called with video_url = {video_url}, loop = {loop}, mute_video = {mute_video}")
         self.driver.execute_script(f"window.botOutputManager.playVideo({json.dumps(video_url)}, {json.dumps(loop)}, {json.dumps(mute_video)})")
 
-    def send_chat_message(self, text, to_user_uuid):
-        self.driver.execute_script("window?.sendChatMessage(arguments[0]);", text)
+    def send_chat_message(self, text, to_user_uuid, pin=False):
+        result = self.driver.execute_async_script(
+            """
+            const done = arguments[arguments.length - 1];
+            Promise.resolve(window?.sendChatMessage(arguments[0], arguments[1]))
+                .then(done)
+                .catch((error) => {
+                    console.error("Error sending Google Meet chat message", error);
+                    done(false);
+                });
+            """,
+            text,
+            pin,
+        )
+        if not result:
+            raise RuntimeError("Google Meet chat message could not be sent or pinned")
 
     def update_closed_captions_language(self, language):
         if self.google_meet_closed_captions_language == language:

--- a/bots/google_meet_bot_adapter/google_meet_chromedriver_payload.js
+++ b/bots/google_meet_bot_adapter/google_meet_chromedriver_payload.js
@@ -95,34 +95,81 @@ const handleVideoTrackForRealTimePerParticipantVideo = async ({ track, streams }
     }
 };
 
-function sendChatMessage(text) {
-    
-    // First try to find the chat input textarea
-    let chatInput = document.querySelector('textarea[aria-label="Send a message"]');
-    
+async function waitForChatElement(getElement, timeoutMs = 5000) {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+        const element = getElement();
+        if (element) {
+            return element;
+        }
+        await new Promise(resolve => setTimeout(resolve, 100));
+    }
+    return null;
+}
+
+function findLatestChatMessageElement(text) {
+    const normalizedText = text.trim();
+    const matchingMessageContainers = Array.from(document.querySelectorAll('[data-message-id]'))
+        .filter(element => Array.from(element.querySelectorAll('*'))
+            .some(descendant => descendant.textContent?.trim() === normalizedText));
+    return matchingMessageContainers.at(-1) || null;
+}
+
+async function pinChatMessage(text) {
+    const pinButton = await waitForChatElement(() => {
+        const messageContainer = findLatestChatMessageElement(text);
+        if (!messageContainer) {
+            return null;
+        }
+
+        messageContainer.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
+        messageContainer.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
+        return messageContainer.querySelector('button[aria-label="Pin"], button[aria-label="Pin message"], [role="button"][aria-label="Pin"], [role="button"][aria-label="Pin message"]');
+    });
+    if (!pinButton) {
+        console.error('Pin action not found for sent chat message');
+        return false;
+    }
+
+    pinButton.click();
+
+    const confirmationButton = await waitForChatElement(() => {
+        const pinningDialog = Array.from(document.querySelectorAll('[role="dialog"]'))
+            .find(dialog => dialog.textContent?.includes('Pinning messages'));
+        return Array.from(pinningDialog?.querySelectorAll('button') || [])
+            .find(button => ['Pin', 'Pin this message'].includes(button.textContent?.trim()));
+    }, 1000);
+    confirmationButton?.click();
+
+    const unpinButton = await waitForChatElement(() => {
+        const messageContainer = findLatestChatMessageElement(text);
+        return messageContainer?.querySelector('button[aria-label="Unpin"], button[aria-label="Unpin message"], [role="button"][aria-label="Unpin"], [role="button"][aria-label="Unpin message"]');
+    }, 3000);
+    return Boolean(unpinButton);
+}
+
+async function sendChatMessage(text, pin = false) {
+    const chatInput = document.querySelector('textarea[aria-label="Send a message"]');
     if (!chatInput) {
         console.error('Chat input not found');
         return false;
     }
-    
-    // Type the message
+
     chatInput.focus();
     chatInput.value = text;
-    
-    // Trigger input event to ensure the UI updates
     chatInput.dispatchEvent(new Event('input', { bubbles: true }));
-    
-    // Send Enter keypress to submit the message
-    const enterEvent = new KeyboardEvent('keydown', {
+    chatInput.dispatchEvent(new KeyboardEvent('keydown', {
         key: 'Enter',
         code: 'Enter',
         keyCode: 13,
         which: 13,
         bubbles: true
-    });
-    chatInput.dispatchEvent(enterEvent);
-    
-    return true;
+    }));
+
+    if (!pin) {
+        return true;
+    }
+    return pinChatMessage(text);
 }
 
 class ParticipantSpeechStartStopManager {

--- a/bots/google_meet_bot_adapter/google_meet_chromedriver_payload.js
+++ b/bots/google_meet_bot_adapter/google_meet_chromedriver_payload.js
@@ -107,54 +107,17 @@ async function waitForChatElement(getElement, timeoutMs = 5000) {
     return null;
 }
 
-function findLatestChatMessageElement(text) {
-    const normalizedText = text.trim();
-    const matchingMessageContainers = Array.from(document.querySelectorAll('[data-message-id]'))
-        .filter(element => Array.from(element.querySelectorAll('*'))
-            .some(descendant => descendant.textContent?.trim() === normalizedText));
-    return matchingMessageContainers.at(-1) || null;
-}
-
-async function pinChatMessage(text) {
-    const pinButton = await waitForChatElement(() => {
-        const messageContainer = findLatestChatMessageElement(text);
-        if (!messageContainer) {
-            return null;
-        }
-
-        messageContainer.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
-        messageContainer.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
-        return messageContainer.querySelector('button[aria-label="Pin"], button[aria-label="Pin message"], [role="button"][aria-label="Pin"], [role="button"][aria-label="Pin message"]');
-    });
-    if (!pinButton) {
-        console.error('Pin action not found for sent chat message');
-        return false;
-    }
-
-    pinButton.click();
-
-    const confirmationButton = await waitForChatElement(() => {
-        const pinningDialog = Array.from(document.querySelectorAll('[role="dialog"]'))
-            .find(dialog => dialog.textContent?.includes('Pinning messages'));
-        return Array.from(pinningDialog?.querySelectorAll('button') || [])
-            .find(button => ['Pin', 'Pin this message'].includes(button.textContent?.trim()));
-    }, 1000);
-    confirmationButton?.click();
-
-    const unpinButton = await waitForChatElement(() => {
-        const messageContainer = findLatestChatMessageElement(text);
-        return messageContainer?.querySelector('button[aria-label="Unpin"], button[aria-label="Unpin message"], [role="button"][aria-label="Unpin"], [role="button"][aria-label="Unpin message"]');
-    }, 3000);
-    return Boolean(unpinButton);
-}
-
-async function sendChatMessage(text, pin = false) {
+async function sendChatMessage(text) {
     const chatInput = document.querySelector('textarea[aria-label="Send a message"]');
     if (!chatInput) {
-        console.error('Chat input not found');
-        return false;
+        return { sent: false, failure_stage: 'chat_input', failure_reason: 'chat_input_not_found' };
     }
 
+    const existingMessageIds = new Set(
+        Array.from(document.querySelectorAll('[data-message-id]'))
+            .map(element => element.getAttribute('data-message-id'))
+            .filter(Boolean)
+    );
     chatInput.focus();
     chatInput.value = text;
     chatInput.dispatchEvent(new Event('input', { bubbles: true }));
@@ -166,10 +129,22 @@ async function sendChatMessage(text, pin = false) {
         bubbles: true
     }));
 
-    if (!pin) {
-        return true;
+    const sentMessage = await waitForChatElement(() =>
+        Array.from(document.querySelectorAll('[data-message-id]')).find(element => {
+            const messageId = element.getAttribute('data-message-id');
+            if (!messageId || existingMessageIds.has(messageId)) {
+                return false;
+            }
+            return Array.from(element.querySelectorAll('div'))
+                .some(descendant => descendant.textContent?.trim() === text);
+        }),
+        10000
+    );
+    if (!sentMessage) {
+        return { sent: false, failure_stage: 'send_acknowledgement', failure_reason: 'sent_message_not_observed' };
     }
-    return pinChatMessage(text);
+
+    return { sent: true, message_id: sentMessage.getAttribute('data-message-id') };
 }
 
 class ParticipantSpeechStartStopManager {

--- a/bots/models.py
+++ b/bots/models.py
@@ -2994,7 +2994,7 @@ class BotChatMessageRequest(models.Model):
 
 class BotChatMessageRequestManager:
     @classmethod
-    def set_chat_message_request_sent(cls, chat_message_request: BotChatMessageRequest):
+    def set_chat_message_request_sent(cls, chat_message_request: BotChatMessageRequest, delivery_data=None):
         if chat_message_request.state == BotChatMessageRequestStates.SENT:
             return
         if chat_message_request.state != BotChatMessageRequestStates.ENQUEUED:
@@ -3002,15 +3002,21 @@ class BotChatMessageRequestManager:
 
         chat_message_request.state = BotChatMessageRequestStates.SENT
         chat_message_request.sent_at_timestamp_ms = int(timezone.now().timestamp() * 1000)
+        if delivery_data:
+            chat_message_request.additional_data = {
+                **chat_message_request.additional_data,
+                "delivery": delivery_data,
+            }
         chat_message_request.save()
 
     @classmethod
-    def set_chat_message_request_failed(cls, chat_message_request: BotChatMessageRequest):
+    def set_chat_message_request_failed(cls, chat_message_request: BotChatMessageRequest, failure_data=None):
         if chat_message_request.state == BotChatMessageRequestStates.FAILED:
             return
         if chat_message_request.state != BotChatMessageRequestStates.ENQUEUED:
             raise ValueError(f"Invalid state transition. Chat message request {chat_message_request.id} is in state {chat_message_request.get_state_display()}")
         chat_message_request.state = BotChatMessageRequestStates.FAILED
+        chat_message_request.failure_data = failure_data
         chat_message_request.save()
 
 

--- a/bots/serializers.py
+++ b/bots/serializers.py
@@ -964,6 +964,7 @@ class BotChatMessageRequestSerializer(serializers.Serializer):
     )
     to = serializers.ChoiceField(choices=BotChatMessageToOptions.values, help_text="Who to send the message to.", default=BotChatMessageToOptions.EVERYONE)
     message = serializers.CharField(help_text="The message text to send. Does not support emojis currently. For Microsoft Teams, you can use basic HTML tags to format the message including <p>, <br>, <b>, <i>, and <a>.")
+    pin = serializers.BooleanField(required=False, default=False, help_text="Whether to pin the message after sending it. Currently supported only for Google Meet.")
 
     def validate(self, data):
         to_value = data.get("to")

--- a/bots/teams_bot_adapter/teams_bot_adapter.py
+++ b/bots/teams_bot_adapter/teams_bot_adapter.py
@@ -99,7 +99,7 @@ class TeamsBotAdapter(WebBotAdapter, TeamsUIMethods):
         logger.info(f"send_video called with video_url = {video_url}, loop = {loop}, mute_video = {mute_video}")
         self.driver.execute_script(f"window.botOutputManager.playVideoWithBlobUrl({json.dumps(video_url)}, {json.dumps(loop)}, {json.dumps(mute_video)})")
 
-    def send_chat_message(self, text, to_user_uuid):
+    def send_chat_message(self, text, to_user_uuid, pin=False):
         chatInput = self.driver.execute_script('return document.querySelector(\'[aria-label="Type a message"], [placeholder="Type a message"]\')')
 
         if not chatInput:

--- a/bots/tests/test_bots_api_utils.py
+++ b/bots/tests/test_bots_api_utils.py
@@ -6,9 +6,10 @@ from django.test import TestCase, override_settings
 from django.utils import timezone
 
 from accounts.models import Organization
-from bots.bots_api_utils import BotCreationSource, build_internal_site_url, build_site_url, create_bot, create_webhook_subscription, patch_bot, validate_bot_concurrency_limit, validate_meeting_url_and_credentials
+from bots.bots_api_utils import BotCreationSource, build_internal_site_url, build_site_url, create_bot, create_bot_chat_message_request, create_webhook_subscription, patch_bot, validate_bot_concurrency_limit, validate_meeting_url_and_credentials
 from bots.calendars_api_utils import create_calendar
-from bots.models import Bot, BotEventManager, BotEventTypes, BotLoginGroup, BotLoginPlatform, BotStates, CalendarEvent, CalendarPlatform, Project, TranscriptionProviders, WebhookSubscription, WebhookTriggerTypes, ZoomOAuthApp
+from bots.models import Bot, BotChatMessageToOptions, BotEventManager, BotEventTypes, BotLoginGroup, BotLoginPlatform, BotStates, CalendarEvent, CalendarPlatform, Project, TranscriptionProviders, WebhookSubscription, WebhookTriggerTypes, ZoomOAuthApp
+from bots.serializers import BotChatMessageRequestSerializer
 
 
 class TestBuildSiteUrl(TestCase):
@@ -104,6 +105,47 @@ class TestCreateBot(TestCase):
         self.assertIsNotNone(bot)
         self.assertIsNotNone(bot.recordings.first())
         self.assertIsNone(error)
+
+    def test_chat_message_serializer_defaults_pin_to_false(self):
+        serializer = BotChatMessageRequestSerializer(data={"to": "everyone", "message": "Regular meeting message"})
+
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        self.assertEqual(serializer.validated_data["pin"], False)
+
+    def test_chat_message_serializer_accepts_pin(self):
+        serializer = BotChatMessageRequestSerializer(data={"to": "everyone", "message": "Important meeting link", "pin": True})
+
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        self.assertEqual(serializer.validated_data["pin"], True)
+
+    def test_create_pinned_bot_chat_message_request(self):
+        bot, error = create_bot(data={"meeting_url": "https://meet.google.com/abc-defg-hij", "bot_name": "Test Bot"}, source=BotCreationSource.API, project=self.project)
+        self.assertIsNone(error)
+
+        chat_message_request = create_bot_chat_message_request(
+            bot,
+            {
+                "to": BotChatMessageToOptions.EVERYONE,
+                "message": "Important meeting link",
+                "pin": True,
+            },
+        )
+
+        self.assertEqual(chat_message_request.additional_data, {"pin": True})
+
+    def test_unpinned_bot_chat_message_request_preserves_empty_additional_data(self):
+        bot, error = create_bot(data={"meeting_url": "https://meet.google.com/abc-defg-hij", "bot_name": "Test Bot"}, source=BotCreationSource.API, project=self.project)
+        self.assertIsNone(error)
+
+        chat_message_request = create_bot_chat_message_request(
+            bot,
+            {
+                "to": BotChatMessageToOptions.EVERYONE,
+                "message": "Regular meeting message",
+            },
+        )
+
+        self.assertEqual(chat_message_request.additional_data, {})
 
     def test_create_zoom_bot_with_default_settings(self):
         ZoomOAuthApp.objects.create(project=self.project, client_id="123")

--- a/bots/tests/test_google_meet_bot_2.py
+++ b/bots/tests/test_google_meet_bot_2.py
@@ -48,23 +48,116 @@ from bots.web_bot_adapter.ui_methods import UiLoginRequiredException, UiRetryabl
 
 
 class TestGoogleMeetChatMessagePinning(TransactionTestCase):
-    def test_send_chat_message_passes_pin_option_to_browser(self):
+    def test_send_chat_message_pins_acknowledged_message_id(self):
         adapter = object.__new__(GoogleMeetBotAdapter)
         adapter.driver = MagicMock()
-        adapter.driver.execute_async_script.return_value = True
+        adapter.driver.execute_async_script.return_value = {
+            "sent": True,
+            "message_id": "message-123",
+        }
 
-        adapter.send_chat_message("Important meeting link", None, pin=True)
+        with patch.object(adapter, "_pin_chat_message", return_value={"pinned": True}) as pin_chat_message:
+            result = adapter.send_chat_message("Important meeting link", None, pin=True)
 
         args = adapter.driver.execute_async_script.call_args.args
-        self.assertEqual(args[1:], ("Important meeting link", True))
+        self.assertEqual(args[1:], ("Important meeting link",))
+        pin_chat_message.assert_called_once_with("message-123", "Important meeting link")
+        self.assertEqual(result, {"sent": True, "message_id": "message-123", "pinned": True})
 
-    def test_send_chat_message_raises_when_browser_operation_fails(self):
+    def test_send_chat_message_returns_acknowledgement_failure_without_pinning(self):
         adapter = object.__new__(GoogleMeetBotAdapter)
         adapter.driver = MagicMock()
-        adapter.driver.execute_async_script.return_value = False
+        adapter.driver.execute_async_script.return_value = {
+            "sent": False,
+            "failure_stage": "send_acknowledgement",
+            "failure_reason": "own_message_not_observed",
+        }
 
-        with self.assertRaisesRegex(RuntimeError, "could not be sent or pinned"):
-            adapter.send_chat_message("Important meeting link", None, pin=True)
+        with patch.object(adapter, "_pin_chat_message") as pin_chat_message:
+            result = adapter.send_chat_message("Important meeting link", None, pin=True)
+
+        pin_chat_message.assert_not_called()
+        self.assertEqual(result["failure_reason"], "own_message_not_observed")
+
+    def test_pin_chat_message_targets_exact_message_id(self):
+        adapter = object.__new__(GoogleMeetBotAdapter)
+        adapter.driver = MagicMock()
+        other_message = MagicMock()
+        other_message.get_attribute.return_value = "other-message"
+        target_message = MagicMock()
+        target_message.get_attribute.return_value = "message-123"
+        target_message.find_elements.side_effect = [[MagicMock()], []]
+        adapter.driver.find_elements.return_value = [other_message, target_message]
+
+        result = adapter._pin_chat_message("message-123", "Important meeting link", timeout_seconds=0.1)
+
+        self.assertTrue(result["pinned"])
+        self.assertEqual(result["message_id"], "message-123")
+        other_message.find_elements.assert_not_called()
+
+    def test_pin_chat_message_uses_browser_click_for_zero_size_pin_control(self):
+        adapter = object.__new__(GoogleMeetBotAdapter)
+        adapter.driver = MagicMock()
+        message = MagicMock()
+        message.get_attribute.return_value = "message-123"
+        pin_button = MagicMock()
+        unpin_button = MagicMock()
+        message.find_elements.side_effect = [[], [pin_button], [unpin_button]]
+        adapter.driver.find_elements.return_value = [message]
+
+        result = adapter._pin_chat_message("message-123", "Important meeting link", timeout_seconds=0.5)
+
+        browser_clicks = [
+            call
+            for call in adapter.driver.execute_script.call_args_list
+            if call.args and call.args[0] == "arguments[0].click();"
+        ]
+        self.assertEqual(browser_clicks[0].args[1], pin_button)
+        pin_button.click.assert_not_called()
+        self.assertTrue(result["pinned"])
+
+    def test_pin_chat_message_falls_back_to_text_when_meet_replaces_message_id(self):
+        adapter = object.__new__(GoogleMeetBotAdapter)
+        adapter.driver = MagicMock()
+        message = MagicMock()
+        message.get_attribute.return_value = "replacement-message-id"
+        unpin_button = MagicMock()
+        message.find_elements.return_value = [unpin_button]
+        adapter.driver.find_elements.return_value = [message]
+        adapter.driver.execute_script.side_effect = [message, None]
+
+        result = adapter._pin_chat_message("temporary-message-id", "Important meeting link", timeout_seconds=0.1)
+
+        self.assertTrue(result["pinned"])
+        self.assertEqual(result["message_id"], "temporary-message-id")
+
+    def test_pin_chat_message_uses_pin_to_board_for_continuous_chat(self):
+        adapter = object.__new__(GoogleMeetBotAdapter)
+        adapter.driver = MagicMock()
+        message = MagicMock()
+        message.get_attribute.return_value = "message-123"
+        more_actions = MagicMock()
+        more_actions.is_displayed.return_value = True
+        message.find_elements.side_effect = [[], [], [], [], [], []]
+        pin_to_board = MagicMock()
+        pin_to_board.text = "Pin to board"
+        pin_to_board.is_displayed.return_value = True
+        unpin_from_board = MagicMock()
+        unpin_from_board.text = "Unpin from board"
+        unpin_from_board.is_displayed.return_value = True
+        adapter.driver.find_elements.side_effect = [
+            [message],
+            [more_actions],
+            [pin_to_board],
+            [message],
+            [more_actions],
+            [unpin_from_board],
+        ]
+
+        result = adapter._pin_chat_message("message-123", "Important meeting link", timeout_seconds=0.5)
+
+        self.assertTrue(result["pinned"])
+        self.assertEqual(result["pin_method"], "board")
 
 
 @override_settings(

--- a/bots/tests/test_google_meet_bot_2.py
+++ b/bots/tests/test_google_meet_bot_2.py
@@ -102,8 +102,24 @@ class TestGoogleMeetChatMessagePinning(TransactionTestCase):
         message.get_attribute.return_value = "message-123"
         pin_button = MagicMock()
         unpin_button = MagicMock()
-        message.find_elements.side_effect = [[], [pin_button], [unpin_button]]
-        adapter.driver.find_elements.return_value = [message]
+
+        def find_message_controls(_, selector):
+            if "Unpin" in selector:
+                return [unpin_button] if pin_button_clicked else []
+            if "Pin message" in selector:
+                return [pin_button]
+            return []
+
+        pin_button_clicked = False
+
+        def execute_script(script, *args):
+            nonlocal pin_button_clicked
+            if script == "arguments[0].click();" and args[0] is pin_button:
+                pin_button_clicked = True
+
+        message.find_elements.side_effect = find_message_controls
+        adapter.driver.find_elements.side_effect = lambda _, selector: [] if selector == '[role="dialog"]' else [message]
+        adapter.driver.execute_script.side_effect = execute_script
 
         result = adapter._pin_chat_message("message-123", "Important meeting link", timeout_seconds=0.5)
 

--- a/bots/tests/test_google_meet_bot_2.py
+++ b/bots/tests/test_google_meet_bot_2.py
@@ -14,6 +14,7 @@ from selenium.common.exceptions import TimeoutException
 
 from bots.bot_adapter import BotAdapter
 from bots.bot_controller import BotController
+from bots.google_meet_bot_adapter.google_meet_bot_adapter import GoogleMeetBotAdapter
 from bots.google_meet_bot_adapter.google_meet_ui_methods import GoogleMeetUIMethods
 from bots.models import (
     Bot,
@@ -44,6 +45,26 @@ from bots.models import (
 )
 from bots.tests.mock_data import create_mock_file_uploader, create_mock_google_meet_driver
 from bots.web_bot_adapter.ui_methods import UiLoginRequiredException, UiRetryableException
+
+
+class TestGoogleMeetChatMessagePinning(TransactionTestCase):
+    def test_send_chat_message_passes_pin_option_to_browser(self):
+        adapter = object.__new__(GoogleMeetBotAdapter)
+        adapter.driver = MagicMock()
+        adapter.driver.execute_async_script.return_value = True
+
+        adapter.send_chat_message("Important meeting link", None, pin=True)
+
+        args = adapter.driver.execute_async_script.call_args.args
+        self.assertEqual(args[1:], ("Important meeting link", True))
+
+    def test_send_chat_message_raises_when_browser_operation_fails(self):
+        adapter = object.__new__(GoogleMeetBotAdapter)
+        adapter.driver = MagicMock()
+        adapter.driver.execute_async_script.return_value = False
+
+        with self.assertRaisesRegex(RuntimeError, "could not be sent or pinned"):
+            adapter.send_chat_message("Important meeting link", None, pin=True)
 
 
 @override_settings(

--- a/bots/tests/test_google_meet_bot_2.py
+++ b/bots/tests/test_google_meet_bot_2.py
@@ -79,6 +79,69 @@ class TestGoogleMeetChatMessagePinning(TransactionTestCase):
         pin_chat_message.assert_not_called()
         self.assertEqual(result["failure_reason"], "own_message_not_observed")
 
+    def test_send_chat_message_defers_missing_pin_action_until_host_joins(self):
+        adapter = object.__new__(GoogleMeetBotAdapter)
+        adapter.driver = MagicMock()
+        adapter.driver.execute_async_script.return_value = {
+            "sent": True,
+            "message_id": "message-123",
+        }
+        adapter.pending_chat_message_pin = None
+        adapter.participants_info = {}
+
+        with patch.object(
+            adapter,
+            "_pin_chat_message",
+            return_value={
+                "pinned": False,
+                "failure_stage": "pin",
+                "failure_reason": "pin_action_not_found",
+            },
+        ):
+            adapter.send_chat_message("Important meeting link", None, pin=True)
+
+        self.assertEqual(
+            adapter.pending_chat_message_pin,
+            {"message_id": "message-123", "text": "Important meeting link"},
+        )
+
+    def test_host_join_retries_deferred_pin_without_resending_message(self):
+        adapter = object.__new__(GoogleMeetBotAdapter)
+        adapter.driver = MagicMock()
+        adapter.pending_chat_message_pin = {
+            "message_id": "message-123",
+            "text": "Important meeting link",
+        }
+
+        with patch(
+            "bots.google_meet_bot_adapter.google_meet_bot_adapter.WebBotAdapter.handle_participant_update"
+        ) as handle_participant_update, patch.object(
+            adapter,
+            "_pin_chat_message",
+            return_value={"pinned": True, "message_id": "message-123"},
+        ) as pin_chat_message:
+            adapter.handle_participant_update({"active": True, "isHost": True})
+
+        handle_participant_update.assert_called_once_with({"active": True, "isHost": True})
+        pin_chat_message.assert_called_once_with("message-123", "Important meeting link")
+        self.assertIsNone(adapter.pending_chat_message_pin)
+        adapter.driver.execute_async_script.assert_not_called()
+
+    def test_non_host_join_does_not_retry_deferred_pin(self):
+        adapter = object.__new__(GoogleMeetBotAdapter)
+        adapter.pending_chat_message_pin = {
+            "message_id": "message-123",
+            "text": "Important meeting link",
+        }
+
+        with patch(
+            "bots.google_meet_bot_adapter.google_meet_bot_adapter.WebBotAdapter.handle_participant_update"
+        ), patch.object(adapter, "_pin_chat_message") as pin_chat_message:
+            adapter.handle_participant_update({"active": True, "isHost": False})
+
+        pin_chat_message.assert_not_called()
+        self.assertIsNotNone(adapter.pending_chat_message_pin)
+
     def test_pin_chat_message_targets_exact_message_id(self):
         adapter = object.__new__(GoogleMeetBotAdapter)
         adapter.driver = MagicMock()

--- a/bots/tests/test_teams_bot.py
+++ b/bots/tests/test_teams_bot.py
@@ -335,6 +335,7 @@ class TestTeamsBot(TransactionTestCase):
                 call_args = mock_send_chat_message.call_args
                 self.assertEqual(call_args.kwargs["text"], "Test message")
                 self.assertEqual(call_args.kwargs["to_user_uuid"], None)
+                self.assertEqual(call_args.kwargs["pin"], False)
 
                 # Verify that the chat message request is now in SENT state
                 chat_message_request.refresh_from_db()

--- a/bots/web_bot_adapter/web_bot_adapter.py
+++ b/bots/web_bot_adapter/web_bot_adapter.py
@@ -1089,7 +1089,7 @@ class WebBotAdapter(BotAdapter):
         # Call the JavaScript function to enqueue the PCM chunk
         self.driver.execute_script("window.botOutputManager.playPCMAudio(arguments[0], arguments[1]);", audio_data, sample_rate)
 
-    def send_chat_message(self, text, to_user_uuid):
+    def send_chat_message(self, text, to_user_uuid, pin=False):
         logger.info("send_chat_message not supported in web bots")
 
     # Sub-classes can override this to add class-specific initial data code

--- a/bots/zoom_bot_adapter/zoom_bot_adapter.py
+++ b/bots/zoom_bot_adapter/zoom_bot_adapter.py
@@ -506,7 +506,7 @@ class ZoomBotAdapter(BotAdapter):
             self.active_sharer_source_id = new_active_sharer_source_id
             self.set_video_input_manager_based_on_state()
 
-    def send_chat_message(self, text, to_user_uuid):
+    def send_chat_message(self, text, to_user_uuid, pin=False):
         # Send a welcome message to the chat
         builder = self.chat_ctrl.GetChatMessageBuilder()
         builder.SetContent(text)

--- a/bots/zoom_web_bot_adapter/zoom_web_bot_adapter.py
+++ b/bots/zoom_web_bot_adapter/zoom_web_bot_adapter.py
@@ -113,7 +113,7 @@ class ZoomWebBotAdapter(WebBotAdapter, ZoomWebUIMethods):
     def change_gallery_view_page(self, next_page: bool):
         self.driver.execute_script(f"window?.changeGalleryViewPage({json.dumps(next_page)})")
 
-    def send_chat_message(self, text, to_user_uuid):
+    def send_chat_message(self, text, to_user_uuid, pin=False):
         self.driver.execute_script("window?.sendChatMessage(arguments[0], arguments[1]);", text, to_user_uuid)
 
     def get_staged_bot_join_delay_seconds(self):


### PR DESCRIPTION
## Problem

Google Meet chat messages sent by a bot are only visible to participants who are present when the message is sent. Participants who join later can therefore miss important information such as meeting links, instructions, or notices.

## Solution

Add an optional `pin` field to the send-chat-message request. When `pin` is `true`, a Google Meet bot sends the message and then pins it so that late joiners can see it.

The option defaults to `false`, preserving the existing behavior for current API clients and other meeting platforms.

## example
```
{
  "to": "everyone",
  "message": "Important meeting link: https://example.com",
  "pin": true
}
```

## Validation

- `python manage.py test --tag google_meet_tests --verbosity 2` — 26 tests passed
- `ruff check .`
- `ruff format --check --diff .`