### PR TITLE
fix: harden SSRF controls for RTMS/media fetches and enable RTMS TLS verify

### DIFF
--- a/bots/app_session_serializers.py
+++ b/bots/app_session_serializers.py
@@ -64,6 +64,14 @@ class CreateAppSessionSerializer(CreateBotSerializer):
         except jsonschema.exceptions.ValidationError as e:
             raise serializers.ValidationError(e.message)
 
+        from bots.ssrf import assert_safe_rtms_websocket_url
+
+        server_urls = value.get("server_urls")
+        try:
+            assert_safe_rtms_websocket_url(server_urls)
+        except ValueError as e:
+            raise serializers.ValidationError({"server_urls": str(e)})
+
         return value
 
     def validate_transcription_settings(self, value):

--- a/bots/serializers.py
+++ b/bots/serializers.py
@@ -1016,7 +1016,12 @@ class OutputVideoRequestSerializer(serializers.Serializer):
             raise serializers.ValidationError("URL must start with https://")
         if not value.endswith(".mp4"):
             raise serializers.ValidationError("URL must end with .mp4")
-        return value
+        from bots.ssrf import assert_safe_https_media_url
+
+        try:
+            return assert_safe_https_media_url(value)
+        except ValueError as e:
+            raise serializers.ValidationError(str(e))
 
 
 WEBSOCKET_SETTINGS_SCHEMA = {

--- a/bots/ssrf.py
+++ b/bots/ssrf.py
@@ -1,0 +1,151 @@
+"""Helpers to block server-side fetches to non-public network destinations (SSRF)."""
+
+from __future__ import annotations
+
+import ipaddress
+import logging
+import os
+import socket
+from urllib.parse import urlsplit
+
+logger = logging.getLogger(__name__)
+
+# Zoom RTMS signaling/media hosts observed in production. Override with
+# ZOOM_RTMS_HOST_SUFFIX_ALLOWLIST (comma-separated). Set to empty string to
+# skip the suffix check and rely only on public-IP resolution.
+_DEFAULT_ZOOM_RTMS_HOST_SUFFIXES = (
+    ".zoom.us",
+    ".zoom.com",
+    ".zoomgov.com",
+    "zoom.us",
+    "zoom.com",
+    "zoomgov.com",
+)
+
+
+def _zoom_rtms_host_suffixes() -> tuple[str, ...] | None:
+    raw = os.getenv("ZOOM_RTMS_HOST_SUFFIX_ALLOWLIST")
+    if raw is None:
+        return _DEFAULT_ZOOM_RTMS_HOST_SUFFIXES
+    raw = raw.strip()
+    if not raw:
+        return None
+    return tuple(s.strip().lower() for s in raw.split(",") if s.strip())
+
+
+def hostname_resolves_public(hostname: str, port: int | None = None) -> bool:
+    """True iff every A/AAAA for hostname is a global (public) unicast address."""
+    if not hostname:
+        return False
+
+    # Literal IP in the URL — no DNS involved.
+    try:
+        ip = ipaddress.ip_address(hostname)
+        return ip.is_global
+    except ValueError:
+        pass
+
+    try:
+        addresses = socket.getaddrinfo(
+            hostname,
+            port or 443,
+            type=socket.SOCK_STREAM,
+        )
+    except socket.gaierror:
+        return False
+
+    if not addresses:
+        return False
+
+    for address in addresses:
+        ip = ipaddress.ip_address(address[4][0])
+        if not ip.is_global:
+            return False
+    return True
+
+
+def url_is_public(url: str) -> bool:
+    """
+    Resolve the URL hostname and require every address to be globally routable.
+
+    Rejects missing host, DNS failures, loopback, link-local, private RFC1918/ULA,
+    and cloud metadata ranges covered by ipaddress.is_global == False.
+    """
+    parsed = urlsplit(url)
+    if not parsed.hostname:
+        return False
+    return hostname_resolves_public(parsed.hostname, parsed.port)
+
+
+def _host_matches_suffixes(hostname: str, suffixes: tuple[str, ...]) -> bool:
+    host = hostname.lower().rstrip(".")
+    for suffix in suffixes:
+        s = suffix.lower().rstrip(".")
+        if host == s or host.endswith(s if s.startswith(".") else f".{s}"):
+            return True
+    return False
+
+
+def assert_safe_rtms_websocket_url(url: str) -> str:
+    """
+    Validate a Zoom RTMS signaling/media WebSocket URL before the worker connects.
+
+    - scheme must be wss://
+    - hostname must match ZOOM_RTMS_HOST_SUFFIX_ALLOWLIST (unless disabled)
+    - DNS must resolve only to public IPs
+    """
+    if not isinstance(url, str) or not url.strip():
+        raise ValueError("RTMS URL is required")
+    url = url.strip()
+    parsed = urlsplit(url)
+    if parsed.scheme != "wss":
+        raise ValueError("RTMS URL must use the wss:// scheme")
+    if not parsed.hostname:
+        raise ValueError("RTMS URL is missing a hostname")
+
+    suffixes = _zoom_rtms_host_suffixes()
+    if suffixes is not None and not _host_matches_suffixes(parsed.hostname, suffixes):
+        raise ValueError(
+            f"RTMS URL host {parsed.hostname!r} is not in the Zoom RTMS allowlist"
+        )
+
+    if not hostname_resolves_public(parsed.hostname, parsed.port or 443):
+        raise ValueError(
+            f"RTMS URL host {parsed.hostname!r} does not resolve to a public address"
+        )
+
+    return url
+
+
+def assert_safe_https_media_url(url: str) -> str:
+    """Validate a server-side HTTPS media fetch URL (e.g. output video MP4)."""
+    if not isinstance(url, str) or not url.strip():
+        raise ValueError("Media URL is required")
+    url = url.strip()
+    parsed = urlsplit(url)
+    if parsed.scheme != "https":
+        raise ValueError("Media URL must use the https:// scheme")
+    if not parsed.hostname:
+        raise ValueError("Media URL is missing a hostname")
+    if not url_is_public(url):
+        raise ValueError("Media URL must resolve to a public address")
+    return url
+
+
+def rtms_ssl_context():
+    """
+    SSL context for Zoom RTMS WebSockets.
+
+    Defaults to certificate verification. Set ZOOM_RTMS_SSL_INSECURE=true only for
+    broken lab environments (restores the previous CERT_NONE behaviour).
+    """
+    import ssl
+
+    insecure = os.getenv("ZOOM_RTMS_SSL_INSECURE", "").lower() in ("1", "true", "yes")
+    if insecure:
+        logger.warning("ZOOM_RTMS_SSL_INSECURE enabled — TLS certificate verification disabled for RTMS")
+        ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+        ctx.check_hostname = False
+        ctx.verify_mode = ssl.CERT_NONE
+        return ctx
+    return ssl.create_default_context()

--- a/bots/tasks/deliver_webhook_task.py
+++ b/bots/tasks/deliver_webhook_task.py
@@ -75,7 +75,9 @@ def deliver_webhook(self, delivery_id):
         delivery.save()
         return
 
-    # If webhook URL is not public, mark as failure and return
+    # If webhook URL is not public, mark as failure and return.
+    # Re-resolve immediately before the POST to shrink the DNS-rebinding window
+    # between an earlier subscription check and delivery.
     if settings.REQUIRE_PUBLIC_WEBHOOK_URLS and not url_is_public(subscription.url):
         delivery.status = WebhookDeliveryAttemptStatus.FAILURE
         error_response = {

--- a/bots/tests/test_ssrf.py
+++ b/bots/tests/test_ssrf.py
@@ -1,0 +1,67 @@
+from unittest.mock import patch
+
+from django.test import SimpleTestCase
+
+from bots.ssrf import (
+    assert_safe_https_media_url,
+    assert_safe_rtms_websocket_url,
+    hostname_resolves_public,
+    rtms_ssl_context,
+    url_is_public,
+)
+
+
+class SsrfHelpersTests(SimpleTestCase):
+    def test_literal_loopback_rejected(self):
+        self.assertFalse(hostname_resolves_public("127.0.0.1"))
+        self.assertFalse(url_is_public("https://127.0.0.1/webhook"))
+
+    def test_literal_private_rejected(self):
+        self.assertFalse(hostname_resolves_public("10.0.0.5"))
+        self.assertFalse(url_is_public("https://10.0.0.5/x"))
+
+    def test_literal_public_accepted(self):
+        self.assertTrue(hostname_resolves_public("8.8.8.8"))
+        self.assertTrue(url_is_public("https://8.8.8.8/webhook"))
+
+    def test_rtms_rejects_non_wss(self):
+        with self.assertRaises(ValueError):
+            assert_safe_rtms_websocket_url("https://rtms.zoom.us/path")
+
+    def test_rtms_rejects_private_host(self):
+        with self.assertRaises(ValueError):
+            assert_safe_rtms_websocket_url("wss://127.0.0.1/rtms")
+
+    def test_rtms_rejects_non_zoom_host(self):
+        with patch("bots.ssrf.hostname_resolves_public", return_value=True):
+            with self.assertRaises(ValueError) as ctx:
+                assert_safe_rtms_websocket_url("wss://evil.example.com/rtms")
+        self.assertIn("allowlist", str(ctx.exception).lower())
+
+    def test_rtms_accepts_zoom_host_when_public(self):
+        with patch("bots.ssrf.hostname_resolves_public", return_value=True):
+            url = assert_safe_rtms_websocket_url("wss://rtms.zoom.us/ws")
+        self.assertEqual(url, "wss://rtms.zoom.us/ws")
+
+    def test_media_url_requires_https_and_public(self):
+        with self.assertRaises(ValueError):
+            assert_safe_https_media_url("http://example.com/a.mp4")
+        with self.assertRaises(ValueError):
+            assert_safe_https_media_url("https://127.0.0.1/a.mp4")
+        self.assertEqual(
+            assert_safe_https_media_url("https://8.8.8.8/a.mp4"),
+            "https://8.8.8.8/a.mp4",
+        )
+
+    def test_rtms_ssl_context_verifies_by_default(self):
+        import ssl
+
+        ctx = rtms_ssl_context()
+        self.assertEqual(ctx.verify_mode, ssl.CERT_REQUIRED)
+
+    def test_rtms_ssl_insecure_opt_in(self):
+        import ssl
+
+        with patch.dict("os.environ", {"ZOOM_RTMS_SSL_INSECURE": "true"}):
+            ctx = rtms_ssl_context()
+        self.assertEqual(ctx.verify_mode, ssl.CERT_NONE)

--- a/bots/webhook_utils.py
+++ b/bots/webhook_utils.py
@@ -1,15 +1,14 @@
 import base64
 import hashlib
 import hmac
-import ipaddress
 import json
 import logging
-import socket
 import uuid
 from functools import partial
-from urllib.parse import urlsplit
 
 from django.db import transaction
+
+from bots.ssrf import url_is_public  # noqa: F401 — re-exported for existing imports
 
 logger = logging.getLogger(__name__)
 
@@ -88,26 +87,3 @@ def verify_signature(payload, signature, secret):
     # Use constant-time comparison to prevent timing attacks
     return hmac.compare_digest(signature, expected_signature)
 
-
-def url_is_public(url: str) -> bool:
-    parsed = urlsplit(url)
-
-    if not parsed.hostname:
-        return False
-
-    try:
-        addresses = socket.getaddrinfo(
-            parsed.hostname,
-            parsed.port or 443,
-            type=socket.SOCK_STREAM,
-        )
-    except socket.gaierror:
-        return False
-
-    for address in addresses:
-        ip = ipaddress.ip_address(address[4][0])
-
-        if not ip.is_global:
-            return False
-
-    return True

--- a/bots/zoom_bot_adapter/mp4_demuxer.py
+++ b/bots/zoom_bot_adapter/mp4_demuxer.py
@@ -55,6 +55,12 @@ class MP4Demuxer:
         """
         Download the file from URL to a temporary file.
         """
+        from bots.ssrf import assert_safe_https_media_url
+
+        # Defense in depth: reject private/link-local destinations even if the
+        # API layer already validated (DNS may have changed since enqueue).
+        assert_safe_https_media_url(self._url)
+
         logger.info(f"Downloading MP4 from {self._url}...")
 
         # Create a temporary file

--- a/bots/zoom_rtms_adapter/zoom_rtms_adapter.py
+++ b/bots/zoom_rtms_adapter/zoom_rtms_adapter.py
@@ -4,7 +4,6 @@ import hashlib
 import hmac
 import json
 import logging
-import ssl
 import threading
 import time
 from datetime import datetime
@@ -144,6 +143,11 @@ def extract_join_info(join_payload: dict):
     if not (meeting_uuid and stream_id and signaling_url):
         raise ValueError(f"join_payload missing required fields. meeting_uuid={meeting_uuid}, rtms_stream_id={stream_id}, server_urls={server_urls}")
 
+    # API clients forward Zoom's meeting.rtms_started payload; reject SSRF to private nets.
+    from bots.ssrf import assert_safe_rtms_websocket_url
+
+    signaling_url = assert_safe_rtms_websocket_url(signaling_url)
+
     return meeting_uuid, stream_id, signaling_url
 
 
@@ -263,11 +267,9 @@ class RTMSClient:
 
     def _build_ssl_context(self, url: str):
         if url.startswith("wss://"):
-            ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
-            # You may want to change this in production:
-            ctx.check_hostname = False
-            ctx.verify_mode = ssl.CERT_NONE
-            return ctx
+            from bots.ssrf import rtms_ssl_context
+
+            return rtms_ssl_context()
         return None
 
     async def _connect_signaling(self) -> None:
@@ -323,6 +325,13 @@ class RTMSClient:
 
                         # Then connect to the media websocket (as before)
                         if media_url:
+                            from bots.ssrf import assert_safe_rtms_websocket_url
+
+                            try:
+                                media_url = assert_safe_rtms_websocket_url(media_url)
+                            except ValueError as e:
+                                logger.error("Rejecting unsafe RTMS media_url: %s", e)
+                                raise
                             logger.info("Connecting to media WebSocket at %s", media_url)
                             asyncio.create_task(self._connect_media(media_url))
                         else:


### PR DESCRIPTION
## Summary

Security hardening for server-side fetches that Attendee workers/bots perform on behalf of API clients.

- **Zoom RTMS SSRF**: validate `server_urls` / `media_url` before connect (`wss://`, Zoom host allowlist, public DNS). API + adapter.
- **RTMS TLS**: default `ssl.create_default_context()`; opt out with `ZOOM_RTMS_SSL_INSECURE=true`.
- **Output video / MP4**: reject non-public HTTPS destinations in serializer + `MP4Demuxer`.
- **Webhooks**: keep `REQUIRE_PUBLIC_WEBHOOK_URLS` default `false` (self-host); already `allow_redirects=False`.

Helpers in `bots/ssrf.py` (re-exported by `webhook_utils.url_is_public`).

### Env knobs

| Variable | Default | Meaning |
|----------|---------|---------|
| `ZOOM_RTMS_HOST_SUFFIX_ALLOWLIST` | `.zoom.us,.zoom.com,.zoomgov.com` | Empty = skip suffix check (public IP only). |
| `ZOOM_RTMS_SSL_INSECURE` | unset/false | Restore previous `CERT_NONE`. |

## Test plan

Local (Mimir): Postgres 15.3 + Redis 7 + Django test settings.

- [x] `bots.tests.test_ssrf` + related utils — **89/89 OK**
- [x] Serializer/SSRF helpers reject loopback/private/non-Zoom RTMS hosts; TLS verify default + insecure opt-in

**Still for CI/maintainer:** full matrix in Docker image; live Zoom RTMS with TLS verify.


---
Contribution from [Cold Code Labs](https://github.com/cold-code-labs) · authored via Brokk · co-authors in commit trailers.
