### PR TITLE
fix: verify Stripe payment before crediting and harden autopay idempotency

### DIFF
--- a/bots/projects_views.py
+++ b/bots/projects_views.py
@@ -1270,8 +1270,10 @@ class ProjectBillingView(AdminRequiredMixin, ProjectUrlContextMixin, ListView):
         return context
 
 
-class CheckoutSuccessView(LoginRequiredMixin, ProjectUrlContextMixin, View):
+class CheckoutSuccessView(AdminRequiredMixin, ProjectUrlContextMixin, View):
     def get(self, request, object_id):
+        project = get_project_for_user(user=request.user, project_object_id=object_id)
+
         session_id = request.GET.get("session_id")
         if not session_id:
             return HttpResponse("No session ID provided", status=400)
@@ -1282,13 +1284,23 @@ class CheckoutSuccessView(LoginRequiredMixin, ProjectUrlContextMixin, View):
         except Exception as e:
             return HttpResponse(f"Error retrieving session details: {e}", status=400)
 
+        # Only credit after Stripe confirms payment. "paid" covers successful card
+        # payments; "no_payment_required" covers zero-amount / already-settled sessions.
+        if checkout_session.payment_status not in ("paid", "no_payment_required"):
+            return HttpResponse(
+                f"Checkout session is not paid (payment_status={checkout_session.payment_status}). Credits will not be added.",
+                status=400,
+            )
+
         process_checkout_session_completed(checkout_session)
 
-        return redirect(reverse("bots:project-billing", kwargs={"object_id": object_id}))
+        return redirect(reverse("bots:project-billing", kwargs={"object_id": project.object_id}))
 
 
-class CreateCheckoutSessionView(LoginRequiredMixin, ProjectUrlContextMixin, View):
+class CreateCheckoutSessionView(AdminRequiredMixin, ProjectUrlContextMixin, View):
     def post(self, request, object_id):
+        project = get_project_for_user(user=request.user, project_object_id=object_id)
+
         # Get the purchase amount from the form submission
         try:
             purchase_amount = float(request.POST.get("purchase_amount", 50.0))
@@ -1325,7 +1337,7 @@ class CreateCheckoutSessionView(LoginRequiredMixin, ProjectUrlContextMixin, View
             success_url=request.build_absolute_uri(reverse("bots:checkout-success", kwargs={"object_id": object_id})) + "?session_id={CHECKOUT_SESSION_ID}",
             cancel_url=request.build_absolute_uri(reverse("bots:project-billing", kwargs={"object_id": object_id})),
             metadata={
-                "organization_id": str(request.user.organization.id),
+                "organization_id": str(project.organization.id),
                 "user_id": str(request.user.id),
                 "credit_amount": str(credit_amount),
             },

--- a/bots/tasks/autopay_charge_task.py
+++ b/bots/tasks/autopay_charge_task.py
@@ -11,6 +11,16 @@ from bots.stripe_utils import credit_amount_for_purchase_amount_dollars
 
 logger = logging.getLogger(__name__)
 
+# Skip re-enqueue if a charge was already queued this recently (race guard).
+# The scheduler uses a longer (1 day) window; this covers concurrent enqueue calls.
+AUTOPAY_ENQUEUE_COOLDOWN_MINUTES = 10
+
+
+def autopay_idempotency_key(organization_id, purchase_amount_cents, when=None):
+    """Stable Stripe idempotency key for autopay (org + amount + UTC day)."""
+    day = (when or timezone.now()).strftime("%Y-%m-%d")
+    return f"autopay-{organization_id}-{purchase_amount_cents}-{day}"
+
 
 @shared_task(
     bind=True,
@@ -66,7 +76,9 @@ def autopay_charge(self, organization_id):
             organization.save()
             return
 
-        # Create payment intent with Stripe
+        # Create payment intent with Stripe.
+        # Use a stable key (not Celery task id) so retries of a new task for the
+        # same org/amount/day do not create a duplicate charge.
         payment_intent = stripe.PaymentIntent.create(
             amount=purchase_amount_cents,
             currency="usd",
@@ -77,7 +89,7 @@ def autopay_charge(self, organization_id):
             description=f"Autopay charge for {credit_amount} Attendee credits",
             metadata={"organization_id": str(organization.id), "credit_amount": str(credit_amount), "autopay": "true"},
             api_key=os.getenv("STRIPE_SECRET_KEY"),
-            idempotency_key=self.request.id,
+            idempotency_key=autopay_idempotency_key(organization.id, purchase_amount_cents),
         )
 
         # Check if payment was not successful
@@ -127,6 +139,14 @@ def autopay_charge(self, organization_id):
 def enqueue_autopay_charge_task(organization: Organization):
     """Enqueue a create autopay charge task for an organization."""
     with transaction.atomic():
+        # Lock row so concurrent enqueue calls cannot race past the cooldown check.
+        organization = Organization.objects.select_for_update().get(id=organization.id)
+        if organization.autopay_charge_task_enqueued_at is not None:
+            cooldown = timezone.timedelta(minutes=AUTOPAY_ENQUEUE_COOLDOWN_MINUTES)
+            if organization.autopay_charge_task_enqueued_at > timezone.now() - cooldown:
+                logger.info(f"Skipping autopay enqueue for organization {organization.id}: already enqueued at {organization.autopay_charge_task_enqueued_at.isoformat()}")
+                return
+
         organization.autopay_charge_task_enqueued_at = timezone.now()
         organization.save()
         autopay_charge.delay(organization.id)

--- a/bots/tests/test_autopay_charge_task.py
+++ b/bots/tests/test_autopay_charge_task.py
@@ -1,11 +1,13 @@
 import os
+from datetime import timedelta
 from unittest.mock import MagicMock, patch
 
 import stripe
 from django.test import TestCase
+from django.utils import timezone
 
 from accounts.models import Organization
-from bots.tasks.autopay_charge_task import autopay_charge, enqueue_autopay_charge_task
+from bots.tasks.autopay_charge_task import autopay_charge, autopay_idempotency_key, enqueue_autopay_charge_task
 
 
 class AutopayChargeTaskTestCase(TestCase):
@@ -61,7 +63,7 @@ class AutopayChargeTaskTestCase(TestCase):
 
         mock_payment_intent_create.assert_called_once_with(
             amount=5000,
-            idempotency_key=None,
+            idempotency_key=autopay_idempotency_key(self.org.id, 5000),
             currency="usd",
             customer="cus_test123",
             payment_method="pm_test123",
@@ -209,6 +211,19 @@ class AutopayChargeTaskTestCase(TestCase):
 
         # Check that the Celery task was queued
         mock_delay.assert_called_once_with(self.org.id)
+
+    @patch("bots.tasks.autopay_charge_task.autopay_charge.delay")
+    def test_enqueue_autopay_charge_task_skips_recent_enqueue(self, mock_delay):
+        """A second enqueue within the cooldown window must not queue another task."""
+        self.org.autopay_charge_task_enqueued_at = timezone.now() - timedelta(minutes=1)
+        self.org.save()
+        first_enqueued_at = self.org.autopay_charge_task_enqueued_at
+
+        enqueue_autopay_charge_task(self.org)
+
+        self.org.refresh_from_db()
+        mock_delay.assert_not_called()
+        self.assertEqual(self.org.autopay_charge_task_enqueued_at, first_enqueued_at)
 
     def test_organization_not_found(self):
         """Test handling of non-existent organization ID"""

--- a/bots/tests/test_stripe_billing.py
+++ b/bots/tests/test_stripe_billing.py
@@ -80,6 +80,7 @@ class StripeBillingTestCase(TestCase):
         mock_session = MagicMock()
         mock_session.payment_intent = "pi_test123"
         mock_session.amount_total = 5000  # $50.00 in cents
+        mock_session.payment_status = "paid"
         mock_session.metadata = {"organization_id": str(self.org.id), "user_id": str(self.user.id), "credit_amount": "100"}
         mock_retrieve.return_value = mock_session
 
@@ -103,6 +104,29 @@ class StripeBillingTestCase(TestCase):
         # Check we got redirected to billing page
         self.assertEqual(response.status_code, 302)
         self.assertEqual(response.url, reverse("bots:project-billing", kwargs={"object_id": self.project.object_id}))
+
+    @patch("bots.projects_views.process_checkout_session_completed")
+    @patch("stripe.checkout.Session.retrieve")
+    def test_checkout_success_rejects_unpaid_session(self, mock_retrieve, mock_process):
+        """Unpaid checkout sessions must not credit the organization."""
+        mock_session = MagicMock()
+        mock_session.payment_intent = "pi_unpaid123"
+        mock_session.amount_total = 5000
+        mock_session.payment_status = "unpaid"
+        mock_session.metadata = {"organization_id": str(self.org.id), "user_id": str(self.user.id), "credit_amount": "100"}
+        mock_retrieve.return_value = mock_session
+
+        initial_credits = self.org.centicredits
+
+        response = self.client.get(reverse("bots:checkout-success", kwargs={"object_id": self.project.object_id}), {"session_id": "cs_unpaid123"})
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn(b"not paid", response.content)
+        mock_process.assert_not_called()
+
+        self.org.refresh_from_db()
+        self.assertEqual(self.org.centicredits, initial_credits)
+        self.assertFalse(CreditTransaction.objects.filter(organization=self.org, stripe_payment_intent_id="pi_unpaid123").exists())
 
     @patch("stripe.checkout.Session.retrieve")
     def test_checkout_success_error_handling(self, mock_retrieve):


### PR DESCRIPTION
## Summary
- **CheckoutSuccessView** credits only when Stripe `payment_status` is `paid` or `no_payment_required`; otherwise 400.
- **CreateCheckoutSessionView** / **CheckoutSuccessView** use `AdminRequiredMixin` + `get_project_for_user`.
- **Autopay** stable Stripe idempotency key `autopay-{org}-{amount}-{UTC day}` + 10-minute enqueue cooldown under `select_for_update`.

## Test plan

Local (Mimir): Postgres 15.3 + Redis 7.

- [x] `test_autopay_charge_task` + `test_stripe_billing` + `test_usage_credits` — **40/40 OK** (Stripe mocked)

**Still for CI/maintainer (optional live Stripe):** test-mode checkout credit; double autopay enqueue → single PaymentIntent.


---
Contribution from [Cold Code Labs](https://github.com/cold-code-labs) · authored via Brokk · co-authors in commit trailers.
