### PR TITLE
fix: verify calendar webhook tokens and Zoom timestamp freshness

### DIFF
--- a/bots/external_webhooks_views.py
+++ b/bots/external_webhooks_views.py
@@ -1,3 +1,4 @@
+import hmac
 import json
 import logging
 import os
@@ -15,6 +16,18 @@ from .stripe_utils import process_checkout_session_completed, process_customer_u
 from .zoom_oauth_connections_utils import _upsert_zoom_meeting_to_zoom_oauth_connection_mapping, _verify_zoom_webhook_signature, compute_zoom_webhook_validation_response
 
 logger = logging.getLogger(__name__)
+
+
+def _expected_calendar_webhook_token(calendar) -> str:
+    """Token/clientState set when creating Google/Microsoft calendar subscriptions."""
+    return json.dumps({"calendar_id": calendar.object_id})
+
+
+def _calendar_webhook_token_is_valid(provided: str | None, calendar) -> bool:
+    if not provided:
+        return False
+    expected = _expected_calendar_webhook_token(calendar)
+    return hmac.compare_digest(provided, expected)
 
 
 @method_decorator(csrf_exempt, name="dispatch")
@@ -43,20 +56,24 @@ class ExternalWebhookMicrosoftCalendarView(View):
                 logger.warning("No notifications found in Microsoft Calendar webhook payload")
                 return HttpResponse(status=200)
 
-            # Process the first notification
             for notification in notifications:
                 subscription_id = notification.get("subscriptionId")
 
                 if not subscription_id:
                     logger.warning("No subscription ID found in Microsoft Calendar webhook notification")
-                    return HttpResponse(status=200)
+                    continue
 
                 # Look up the calendar notification channel by subscription ID
                 calendar_notification_channel = CalendarNotificationChannel.objects.filter(platform_uuid=subscription_id).first()
                 if not calendar_notification_channel:
                     logger.warning(f"No calendar notification channel found for subscription ID: {subscription_id}")
                     # TODO make request to stop the subscription in Microsoft Graph API
-                    return HttpResponse(status=200)
+                    continue
+
+                # Require clientState to match what we set when creating the subscription
+                if not _calendar_webhook_token_is_valid(notification.get("clientState"), calendar_notification_channel.calendar):
+                    logger.warning(f"Invalid or missing clientState for subscription ID: {subscription_id}")
+                    continue
 
                 # Update the last received timestamp
                 calendar_notification_channel.notification_last_received_at = timezone.now()
@@ -98,6 +115,12 @@ class ExternalWebhookGoogleCalendarView(View):
         if not calendar_notification_channel:
             logger.warning(f"No calendar notification channel found for channel ID: {channel_id}")
             # TODO make request to stop the channel in Google API
+            return HttpResponse(status=200)
+
+        # Require channel token to match what we set when creating the watch channel
+        channel_token = request.headers.get("X-Goog-Channel-Token")
+        if not _calendar_webhook_token_is_valid(channel_token, calendar_notification_channel.calendar):
+            logger.warning(f"Invalid or missing channel token for channel ID: {channel_id}")
             return HttpResponse(status=200)
 
         calendar_notification_channel.notification_last_received_at = timezone.now()

--- a/bots/models.py
+++ b/bots/models.py
@@ -288,11 +288,13 @@ class ZoomOAuthApp(models.Model):
 
     @property
     def client_secret(self):
-        return self.get_credentials().get("client_secret")
+        credentials = self.get_credentials()
+        return credentials.get("client_secret") if credentials else None
 
     @property
     def webhook_secret(self):
-        return self.get_credentials().get("webhook_secret")
+        credentials = self.get_credentials()
+        return credentials.get("webhook_secret") if credentials else None
 
     def set_credentials(self, credentials_dict):
         """Encrypt and save credentials"""

--- a/bots/tests/test_calendar_external_webhooks.py
+++ b/bots/tests/test_calendar_external_webhooks.py
@@ -6,6 +6,7 @@ from django.urls import reverse
 from django.utils import timezone
 
 from accounts.models import Organization
+from bots.external_webhooks_views import _expected_calendar_webhook_token
 from bots.models import (
     Calendar,
     CalendarNotificationChannel,
@@ -33,6 +34,7 @@ class TestGoogleCalendarWebhooks(TestCase):
             expires_at=timezone.now() + timedelta(days=7),
             raw={"test": "data"},
         )
+        self.channel_token = _expected_calendar_webhook_token(self.calendar)
         self.url = reverse("external_webhooks:external-webhook-google-calendar")
 
     def test_google_webhook_success(self):
@@ -42,6 +44,7 @@ class TestGoogleCalendarWebhooks(TestCase):
             data="",
             content_type="application/json",
             HTTP_X_GOOG_CHANNEL_ID="test_channel_123",
+            HTTP_X_GOOG_CHANNEL_TOKEN=self.channel_token,
             HTTP_X_GOOG_RESOURCE_STATE="exists",
         )
 
@@ -62,6 +65,7 @@ class TestGoogleCalendarWebhooks(TestCase):
             data="",
             content_type="application/json",
             HTTP_X_GOOG_CHANNEL_ID="test_channel_123",
+            HTTP_X_GOOG_CHANNEL_TOKEN=self.channel_token,
             HTTP_X_GOOG_RESOURCE_STATE="sync",
         )
 
@@ -82,6 +86,7 @@ class TestGoogleCalendarWebhooks(TestCase):
             data="",
             content_type="application/json",
             HTTP_X_GOOG_CHANNEL_ID="unknown_channel_id",
+            HTTP_X_GOOG_CHANNEL_TOKEN=self.channel_token,
             HTTP_X_GOOG_RESOURCE_STATE="exists",
         )
 
@@ -108,6 +113,35 @@ class TestGoogleCalendarWebhooks(TestCase):
         self.notification_channel.refresh_from_db()
         self.assertIsNone(self.notification_channel.notification_last_received_at)
 
+    def test_google_webhook_spoof_with_channel_id_only_rejected(self):
+        """Spoofing with channel UUID alone (no/invalid token) must not trigger sync."""
+        response = self.client.post(
+            self.url,
+            data="",
+            content_type="application/json",
+            HTTP_X_GOOG_CHANNEL_ID="test_channel_123",
+            HTTP_X_GOOG_RESOURCE_STATE="exists",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.notification_channel.refresh_from_db()
+        self.assertIsNone(self.notification_channel.notification_last_received_at)
+        self.calendar.refresh_from_db()
+        self.assertIsNone(self.calendar.sync_task_requested_at)
+
+        response = self.client.post(
+            self.url,
+            data="",
+            content_type="application/json",
+            HTTP_X_GOOG_CHANNEL_ID="test_channel_123",
+            HTTP_X_GOOG_CHANNEL_TOKEN=json.dumps({"calendar_id": "cal_wrong"}),
+            HTTP_X_GOOG_RESOURCE_STATE="exists",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.notification_channel.refresh_from_db()
+        self.assertIsNone(self.notification_channel.notification_last_received_at)
+
     def test_google_webhook_update_resource_state(self):
         """Test Google webhook with 'update' resource state."""
         response = self.client.post(
@@ -115,6 +149,7 @@ class TestGoogleCalendarWebhooks(TestCase):
             data="",
             content_type="application/json",
             HTTP_X_GOOG_CHANNEL_ID="test_channel_123",
+            HTTP_X_GOOG_CHANNEL_TOKEN=self.channel_token,
             HTTP_X_GOOG_RESOURCE_STATE="update",
         )
 
@@ -144,6 +179,7 @@ class TestGoogleCalendarWebhooks(TestCase):
             data="",
             content_type="application/json",
             HTTP_X_GOOG_CHANNEL_ID="test_channel_123",
+            HTTP_X_GOOG_CHANNEL_TOKEN=self.channel_token,
             HTTP_X_GOOG_RESOURCE_STATE="exists",
         )
 
@@ -176,6 +212,7 @@ class TestMicrosoftCalendarWebhooks(TestCase):
             expires_at=timezone.now() + timedelta(days=7),
             raw={"test": "data"},
         )
+        self.client_state = _expected_calendar_webhook_token(self.calendar)
         self.url = reverse("external_webhooks:external-webhook-microsoft-calendar")
 
     def test_microsoft_webhook_validation_request(self):
@@ -199,6 +236,7 @@ class TestMicrosoftCalendarWebhooks(TestCase):
             "value": [
                 {
                     "subscriptionId": "test_subscription_123",
+                    "clientState": self.client_state,
                     "changeType": "created",
                     "resource": "me/events/event_id_123",
                 }
@@ -221,12 +259,54 @@ class TestMicrosoftCalendarWebhooks(TestCase):
         self.calendar.refresh_from_db()
         self.assertIsNotNone(self.calendar.sync_task_requested_at)
 
+    def test_microsoft_webhook_spoof_with_subscription_id_only_rejected(self):
+        """Spoofing with subscription UUID alone (no/invalid clientState) must not trigger sync."""
+        payload_missing = {
+            "value": [
+                {
+                    "subscriptionId": "test_subscription_123",
+                    "changeType": "created",
+                    "resource": "me/events/event_id_123",
+                }
+            ]
+        }
+        response = self.client.post(
+            self.url,
+            data=json.dumps(payload_missing),
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 200)
+        self.notification_channel.refresh_from_db()
+        self.assertIsNone(self.notification_channel.notification_last_received_at)
+
+        payload_wrong = {
+            "value": [
+                {
+                    "subscriptionId": "test_subscription_123",
+                    "clientState": json.dumps({"calendar_id": "cal_wrong"}),
+                    "changeType": "created",
+                    "resource": "me/events/event_id_123",
+                }
+            ]
+        }
+        response = self.client.post(
+            self.url,
+            data=json.dumps(payload_wrong),
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 200)
+        self.notification_channel.refresh_from_db()
+        self.assertIsNone(self.notification_channel.notification_last_received_at)
+        self.calendar.refresh_from_db()
+        self.assertIsNone(self.calendar.sync_task_requested_at)
+
     def test_microsoft_webhook_unknown_subscription_id(self):
         """Test Microsoft webhook with unknown subscription ID returns 200 but does nothing."""
         payload = {
             "value": [
                 {
                     "subscriptionId": "unknown_subscription_id",
+                    "clientState": self.client_state,
                     "changeType": "created",
                     "resource": "me/events/event_id_123",
                 }
@@ -312,16 +392,19 @@ class TestMicrosoftCalendarWebhooks(TestCase):
             expires_at=timezone.now() + timedelta(days=7),
             raw={"test": "data"},
         )
+        other_client_state = _expected_calendar_webhook_token(other_calendar)
 
         payload = {
             "value": [
                 {
                     "subscriptionId": "test_subscription_123",
+                    "clientState": self.client_state,
                     "changeType": "created",
                     "resource": "me/events/event_id_1",
                 },
                 {
                     "subscriptionId": "other_subscription_456",
+                    "clientState": other_client_state,
                     "changeType": "updated",
                     "resource": "me/events/event_id_2",
                 },
@@ -350,12 +433,67 @@ class TestMicrosoftCalendarWebhooks(TestCase):
         other_calendar.refresh_from_db()
         self.assertIsNotNone(other_calendar.sync_task_requested_at)
 
+    def test_microsoft_webhook_continues_after_invalid_item_in_batch(self):
+        """Invalid items must not short-circuit processing of later valid notifications."""
+        other_calendar = Calendar.objects.create(
+            project=self.project,
+            platform=CalendarPlatform.MICROSOFT,
+            client_id="other_client_id",
+        )
+        other_channel = CalendarNotificationChannel.objects.create(
+            calendar=other_calendar,
+            platform_uuid="other_subscription_456",
+            unique_key="notification_channel_" + other_calendar.object_id,
+            expires_at=timezone.now() + timedelta(days=7),
+            raw={"test": "data"},
+        )
+        other_client_state = _expected_calendar_webhook_token(other_calendar)
+
+        payload = {
+            "value": [
+                {
+                    # Missing subscriptionId — previously caused early return
+                    "changeType": "created",
+                    "resource": "me/events/event_id_1",
+                },
+                {
+                    "subscriptionId": "unknown_subscription_id",
+                    "clientState": self.client_state,
+                    "changeType": "created",
+                    "resource": "me/events/event_id_2",
+                },
+                {
+                    "subscriptionId": "other_subscription_456",
+                    "clientState": other_client_state,
+                    "changeType": "updated",
+                    "resource": "me/events/event_id_3",
+                },
+            ]
+        }
+
+        response = self.client.post(
+            self.url,
+            data=json.dumps(payload),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        self.notification_channel.refresh_from_db()
+        self.assertIsNone(self.notification_channel.notification_last_received_at)
+
+        other_channel.refresh_from_db()
+        self.assertIsNotNone(other_channel.notification_last_received_at)
+        other_calendar.refresh_from_db()
+        self.assertIsNotNone(other_calendar.sync_task_requested_at)
+
     def test_microsoft_webhook_updated_change_type(self):
         """Test Microsoft webhook with 'updated' change type."""
         payload = {
             "value": [
                 {
                     "subscriptionId": "test_subscription_123",
+                    "clientState": self.client_state,
                     "changeType": "updated",
                     "resource": "me/events/event_id_123",
                 }
@@ -380,6 +518,7 @@ class TestMicrosoftCalendarWebhooks(TestCase):
             "value": [
                 {
                     "subscriptionId": "test_subscription_123",
+                    "clientState": self.client_state,
                     "changeType": "deleted",
                     "resource": "me/events/event_id_123",
                 }

--- a/bots/tests/test_zoom_oauth_apps_api_utils.py
+++ b/bots/tests/test_zoom_oauth_apps_api_utils.py
@@ -293,6 +293,12 @@ class TestCreateOrUpdateZoomOAuthApp(TestCase):
         self.assertEqual(credentials["client_secret"], "existing_client_secret")
         self.assertEqual(credentials["webhook_secret"], "existing_webhook_secret")
 
+    def test_credential_properties_when_encrypted_data_missing(self):
+        """Missing encrypted credentials should return None, not AttributeError."""
+        zoom_oauth_app = ZoomOAuthApp.objects.create(project=self.project, client_id="test_client_id_no_creds")
+        self.assertIsNone(zoom_oauth_app.client_secret)
+        self.assertIsNone(zoom_oauth_app.webhook_secret)
+
 
 class TestZoomOAuthAppDeletion(TestCase):
     """Test deletion constraints for ZoomOAuthApp."""

--- a/bots/tests/test_zoom_oauth_connections_utils.py
+++ b/bots/tests/test_zoom_oauth_connections_utils.py
@@ -14,6 +14,7 @@ from bots.models import (
 from bots.zoom_oauth_connections_utils import (
     ZoomAPIAuthenticationError,
     _handle_zoom_api_authentication_error,
+    _verify_zoom_webhook_signature,
     compute_zoom_webhook_validation_response,
     get_zoom_tokens_via_zoom_oauth_app,
 )
@@ -65,6 +66,38 @@ class TestComputeZoomWebhookValidationResponse(TestCase):
         result2 = compute_zoom_webhook_validation_response(plain_token, "secret2")
 
         self.assertNotEqual(result1["encryptedToken"], result2["encryptedToken"])
+
+
+class TestVerifyZoomWebhookSignature(TestCase):
+    """Test Zoom webhook signature verification with freshness window."""
+
+    def test_valid_signature_with_fresh_timestamp(self):
+        import hashlib
+        import hmac
+        import time
+
+        body = '{"event":"meeting.created"}'
+        secret = "test_secret"
+        timestamp = str(int(time.time()))
+        signature = f"v0={hmac.new(secret.encode(), f'v0:{timestamp}:{body}'.encode(), hashlib.sha256).hexdigest()}"
+
+        self.assertTrue(_verify_zoom_webhook_signature(body, timestamp, signature, secret))
+
+    def test_rejects_stale_timestamp(self):
+        import hashlib
+        import hmac
+        import time
+
+        body = '{"event":"meeting.created"}'
+        secret = "test_secret"
+        timestamp = str(int(time.time()) - 6 * 60)
+        signature = f"v0={hmac.new(secret.encode(), f'v0:{timestamp}:{body}'.encode(), hashlib.sha256).hexdigest()}"
+
+        self.assertFalse(_verify_zoom_webhook_signature(body, timestamp, signature, secret))
+
+    def test_rejects_missing_secret(self):
+        self.assertFalse(_verify_zoom_webhook_signature("{}", str(int(__import__('time').time())), "v0=abc", None))
+        self.assertFalse(_verify_zoom_webhook_signature("{}", str(int(__import__('time').time())), "v0=abc", ""))
 
 
 class TestHandleZoomApiAuthenticationError(TestCase):

--- a/bots/tests/test_zoom_oauth_external_webhooks.py
+++ b/bots/tests/test_zoom_oauth_external_webhooks.py
@@ -1,6 +1,7 @@
 import hashlib
 import hmac
 import json
+import time
 from unittest.mock import patch
 
 from django.test import Client, TestCase
@@ -46,7 +47,7 @@ class TestZoomOAuthWebhooks(TestCase):
             },
         }
         body = json.dumps(event_data)
-        timestamp = "1234567890"
+        timestamp = str(int(time.time()))
         signature = self._generate_zoom_signature(body, timestamp, "test_webhook_secret")
 
         response = self.client.post(
@@ -79,7 +80,7 @@ class TestZoomOAuthWebhooks(TestCase):
             },
         }
         body = json.dumps(event_data)
-        timestamp = "1234567890"
+        timestamp = str(int(time.time()))
         signature = self._generate_zoom_signature(body, timestamp, "test_webhook_secret")
 
         response = self.client.post(
@@ -107,7 +108,7 @@ class TestZoomOAuthWebhooks(TestCase):
             },
         }
         body = json.dumps(event_data)
-        timestamp = "1234567890"
+        timestamp = str(int(time.time()))
         signature = self._generate_zoom_signature(body, timestamp, "test_webhook_secret")
 
         response = self.client.post(
@@ -135,7 +136,7 @@ class TestZoomOAuthWebhooks(TestCase):
             },
         }
         body = json.dumps(event_data)
-        timestamp = "1234567890"
+        timestamp = str(int(time.time()))
         signature = self._generate_zoom_signature(body, timestamp, "test_webhook_secret")
 
         response = self.client.post(
@@ -168,7 +169,7 @@ class TestZoomOAuthWebhooks(TestCase):
             },
         }
         body = json.dumps(event_data)
-        timestamp = "1234567890"
+        timestamp = str(int(time.time()))
         signature = self._generate_zoom_signature(body, timestamp, "test_webhook_secret")
 
         response = self.client.post(
@@ -196,7 +197,7 @@ class TestZoomOAuthWebhooks(TestCase):
             },
         }
         body = json.dumps(event_data)
-        timestamp = "1234567890"
+        timestamp = str(int(time.time()))
         signature = self._generate_zoom_signature(body, timestamp, "test_webhook_secret")
 
         response = self.client.post(
@@ -224,7 +225,7 @@ class TestZoomOAuthWebhooks(TestCase):
             },
         }
         body = json.dumps(event_data)
-        timestamp = "1234567890"
+        timestamp = str(int(time.time()))
         signature = self._generate_zoom_signature(body, timestamp, "test_webhook_secret")
 
         response = self.client.post(
@@ -252,7 +253,7 @@ class TestZoomOAuthWebhooks(TestCase):
             },
         }
         body = json.dumps(event_data)
-        timestamp = "1234567890"
+        timestamp = str(int(time.time()))
         signature = self._generate_zoom_signature(body, timestamp, "test_webhook_secret")
 
         response = self.client.post(
@@ -280,7 +281,7 @@ class TestZoomOAuthWebhooks(TestCase):
             },
         }
         body = json.dumps(event_data)
-        timestamp = "1234567890"
+        timestamp = str(int(time.time()))
         invalid_signature = "v0=invalid_signature_hash"
 
         response = self.client.post(
@@ -302,6 +303,30 @@ class TestZoomOAuthWebhooks(TestCase):
         self.assertIsNotNone(self.zoom_oauth_app.last_unverified_webhook_received_at)
         self.assertIsNone(self.zoom_oauth_app.last_verified_webhook_received_at)
 
+    def test_stale_timestamp_rejected(self):
+        """Valid signature with a stale timestamp must be rejected (replay protection)."""
+        event_data = {
+            "event": "meeting.created",
+            "payload": {
+                "object": {"id": "123456789", "host_id": "test_user_123"},
+                "operator_id": "test_user_123",
+            },
+        }
+        body = json.dumps(event_data)
+        timestamp = str(int(time.time()) - 6 * 60)
+        signature = self._generate_zoom_signature(body, timestamp, "test_webhook_secret")
+
+        response = self.client.post(
+            self.url,
+            data=body,
+            content_type="application/json",
+            HTTP_X_ZM_SIGNATURE=signature,
+            HTTP_X_ZM_REQUEST_TIMESTAMP=timestamp,
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIsNone(ZoomMeetingToZoomOAuthConnectionMapping.objects.filter(meeting_id="123456789").first())
+
     def test_nonexistent_zoom_oauth_app(self):
         """Test webhook for non-existent ZoomOAuthApp."""
         event_data = {
@@ -312,7 +337,7 @@ class TestZoomOAuthWebhooks(TestCase):
             },
         }
         body = json.dumps(event_data)
-        timestamp = "1234567890"
+        timestamp = str(int(time.time()))
         signature = self._generate_zoom_signature(body, timestamp, "test_webhook_secret")
 
         # Use non-existent object_id
@@ -337,7 +362,7 @@ class TestZoomOAuthWebhooks(TestCase):
             },
         }
         body = json.dumps(event_data)
-        timestamp = "1234567890"
+        timestamp = str(int(time.time()))
         signature = self._generate_zoom_signature(body, timestamp, "test_webhook_secret")
 
         response = self.client.post(
@@ -387,7 +412,7 @@ class TestZoomOAuthWebhooks(TestCase):
             },
         }
         body = json.dumps(event_data)
-        timestamp = "1234567890"
+        timestamp = str(int(time.time()))
         signature = self._generate_zoom_signature(body, timestamp, "test_webhook_secret")
 
         response = self.client.post(
@@ -417,7 +442,7 @@ class TestZoomOAuthWebhooks(TestCase):
             },
         }
         body = json.dumps(event_data)
-        timestamp = "1234567890"
+        timestamp = str(int(time.time()))
         signature = self._generate_zoom_signature(body, timestamp, "test_webhook_secret")
 
         response = self.client.post(
@@ -459,7 +484,7 @@ class TestZoomOAuthWebhooks(TestCase):
             },
         }
         body = json.dumps(event_data)
-        timestamp = "1234567890"
+        timestamp = str(int(time.time()))
         signature = self._generate_zoom_signature(body, timestamp, "test_webhook_secret")
 
         response = self.client.post(
@@ -490,7 +515,7 @@ class TestZoomOAuthWebhooks(TestCase):
             },
         }
         body = json.dumps(event_data)
-        timestamp = "1234567890"
+        timestamp = str(int(time.time()))
         signature = self._generate_zoom_signature(body, timestamp, "test_webhook_secret")
 
         response = self.client.post(

--- a/bots/zoom_oauth_connections_utils.py
+++ b/bots/zoom_oauth_connections_utils.py
@@ -1,6 +1,7 @@
 import hashlib
 import hmac
 import logging
+import time
 
 import requests
 from django.db import transaction
@@ -12,6 +13,27 @@ from bots.webhook_payloads import zoom_oauth_connection_webhook_payload
 from bots.webhook_utils import trigger_webhook
 
 logger = logging.getLogger(__name__)
+
+# Zoom recommends rejecting webhooks whose timestamp is too far from now (replay protection).
+ZOOM_WEBHOOK_TIMESTAMP_TOLERANCE_SECONDS = 5 * 60
+
+
+def _verify_zoom_webhook_signature(body: str, timestamp: str, signature: str, secret: str):
+    """Verify the Zoom webhook signature and timestamp freshness."""
+    if not timestamp or not signature or not secret:
+        return False
+
+    try:
+        request_timestamp = int(timestamp)
+    except (TypeError, ValueError):
+        return False
+
+    if abs(int(time.time()) - request_timestamp) > ZOOM_WEBHOOK_TIMESTAMP_TOLERANCE_SECONDS:
+        return False
+
+    hmac_hash = hmac.new(secret.encode("utf-8"), f"v0:{timestamp}:{body}".encode("utf-8"), hashlib.sha256).hexdigest()
+    expected_signature = f"v0={hmac_hash}"
+    return hmac.compare_digest(expected_signature, signature)
 
 
 class ZoomAPIError(Exception):
@@ -44,13 +66,6 @@ def client_id_and_secret_is_valid(client_id: str, client_secret: str) -> bool:
     except Exception as e:
         logger.exception(f"Error validating Zoom OAuth client_id and client_secret: {e}")
         return False
-
-
-def _verify_zoom_webhook_signature(body: str, timestamp: str, signature: str, secret: str):
-    """Verify the Zoom webhook signature."""
-    hmac_hash = hmac.new(secret.encode("utf-8"), f"v0:{timestamp}:{body}".encode("utf-8"), hashlib.sha256).hexdigest()
-    expected_signature = f"v0={hmac_hash}"
-    return expected_signature == signature
 
 
 def compute_zoom_webhook_validation_response(plain_token: str, secret_token: str) -> dict:


### PR DESCRIPTION
## Summary

- **Microsoft Calendar**: verify `clientState` (`{"calendar_id": …}`); UUID alone ignored; batch uses `continue` not early `return`.
- **Google Calendar**: verify `X-Goog-Channel-Token`.
- **Zoom**: 5-minute timestamp freshness + `hmac.compare_digest`.
- **ZoomOAuthApp**: missing encrypted credentials → `None` (no AttributeError).

## Test plan

Local (Mimir): Postgres 15.3 + Redis 7.

- [x] Calendar + Zoom external webhooks + OAuth utils — **65/65 OK** (spoof/stale/fresh/`compare_digest`)

**Still for CI:** same modules in project Docker test env.


---
Contribution from [Cold Code Labs](https://github.com/cold-code-labs) · authored via Brokk · co-authors in commit trailers.
