### PR TITLE
fix: serialize OAuth refresh/sync and harden async transcription races

### DIFF
--- a/bots/redis_utils.py
+++ b/bots/redis_utils.py
@@ -1,5 +1,16 @@
 # Lua fallback for Redis < 7 which doesn't support EXPIRE ... NX.
+import logging
+from contextlib import contextmanager
+from threading import local
+
+import redis
+from django.conf import settings
+
+logger = logging.getLogger(__name__)
+
 _redis_lua_script_incr_and_expire_nx = None
+_redis_client = None
+_held_lock_keys = local()
 
 
 def _get_redis_lua_script_incr_and_expire_nx(redis_client):
@@ -28,3 +39,67 @@ def incr_and_expire_nx(redis_client, key, ttl):
     script = _get_redis_lua_script_incr_and_expire_nx(redis_client)
     count, ttl_set = script(keys=[key], args=[ttl])
     return count, ttl_set
+
+
+def get_redis_client():
+    """Process-wide Redis client for locks and shared utilities."""
+    global _redis_client
+    if _redis_client is None:
+        _redis_client = redis.from_url(settings.REDIS_URL_WITH_PARAMS)
+    return _redis_client
+
+
+def zoom_oauth_connection_token_lock_key(zoom_oauth_connection_id) -> str:
+    return f"lock:zoom-oauth-connection-token:{zoom_oauth_connection_id}"
+
+
+def calendar_sync_lock_key(calendar_id) -> str:
+    return f"lock:calendar-sync:{calendar_id}"
+
+
+@contextmanager
+def redis_lock(key: str, timeout: int = 180, blocking_timeout: int = 180):
+    """
+    Blocking Redis lock.
+
+    Re-entrant for the same key within the same thread so task-level locks can
+    nest around helpers that also take the lock (e.g. token refresh).
+    """
+    held = getattr(_held_lock_keys, "keys", None)
+    if held is None:
+        held = set()
+        _held_lock_keys.keys = held
+
+    if key in held:
+        yield
+        return
+
+    client = get_redis_client()
+    lock = client.lock(key, timeout=timeout, blocking_timeout=blocking_timeout)
+    acquired = lock.acquire(blocking=True)
+    if not acquired:
+        raise TimeoutError(f"Could not acquire redis lock {key} within {blocking_timeout}s")
+
+    held.add(key)
+    try:
+        yield
+    finally:
+        held.discard(key)
+        try:
+            lock.release()
+        except redis.exceptions.LockError:
+            logger.warning("Redis lock %s already released or expired", key)
+
+
+@contextmanager
+def zoom_oauth_connection_token_lock(zoom_oauth_connection_id, timeout: int = 180, blocking_timeout: int = 180):
+    """Serialize Zoom OAuth token refresh for a connection (refresh/sync/join)."""
+    with redis_lock(zoom_oauth_connection_token_lock_key(zoom_oauth_connection_id), timeout=timeout, blocking_timeout=blocking_timeout):
+        yield
+
+
+@contextmanager
+def calendar_sync_lock(calendar_id, timeout: int = 300, blocking_timeout: int = 300):
+    """Serialize calendar sync mutations (esp. Microsoft refresh_token rotation)."""
+    with redis_lock(calendar_sync_lock_key(calendar_id), timeout=timeout, blocking_timeout=blocking_timeout):
+        yield

--- a/bots/tasks/process_async_transcription_task.py
+++ b/bots/tasks/process_async_transcription_task.py
@@ -3,6 +3,7 @@ import math
 import os
 
 from celery import shared_task
+from django.db import transaction
 from django.utils import timezone
 
 from bots.models import AsyncTranscription, AsyncTranscriptionManager, AsyncTranscriptionStates, TranscriptionFailureReasons, Utterance
@@ -144,17 +145,22 @@ def check_for_transcription_completion(async_transcription):
     soft_time_limit=3600,
 )
 def process_async_transcription(self, async_transcription_id):
-    async_transcription = AsyncTranscription.objects.get(id=async_transcription_id)
-
     try:
-        if async_transcription.state == AsyncTranscriptionStates.COMPLETE or async_transcription.state == AsyncTranscriptionStates.FAILED:
-            return
+        with transaction.atomic():
+            # Claim NOT_STARTED with a row lock so concurrent workers cannot both create utterances.
+            async_transcription = AsyncTranscription.objects.select_for_update().get(id=async_transcription_id)
 
-        if async_transcription.state == AsyncTranscriptionStates.NOT_STARTED:
-            create_utterances_for_transcription(async_transcription)
+            if async_transcription.state == AsyncTranscriptionStates.COMPLETE or async_transcription.state == AsyncTranscriptionStates.FAILED:
+                return
 
-        check_for_transcription_completion(async_transcription)
+            if async_transcription.state == AsyncTranscriptionStates.NOT_STARTED:
+                create_utterances_for_transcription(async_transcription)
+
+        async_transcription.refresh_from_db()
+        if async_transcription.state == AsyncTranscriptionStates.IN_PROGRESS:
+            check_for_transcription_completion(async_transcription)
 
     except Exception as e:
         logger.exception(f"Unexpected exception in process_async_transcription: {str(e)}")
+        async_transcription = AsyncTranscription.objects.get(id=async_transcription_id)
         AsyncTranscriptionManager.set_async_transcription_failed(async_transcription, failure_data={})

--- a/bots/tasks/process_utterance_group_for_async_transcription_task.py
+++ b/bots/tasks/process_utterance_group_for_async_transcription_task.py
@@ -1,11 +1,18 @@
 import logging
 
 from celery import shared_task
+from django.db import transaction
 
 logger = logging.getLogger(__name__)
 
-from bots.models import Utterance
+from bots.models import TranscriptionFailureReasons, Utterance
 from bots.transcription_utils import get_transcription_for_utterance_group, is_retryable_failure
+
+MAX_UTTERANCE_GROUP_ATTEMPTS = 5
+
+
+class RetryableUtteranceGroupTranscriptionError(Exception):
+    """Raised to trigger Celery retry for a retryable utterance-group transcription failure."""
 
 
 @shared_task(
@@ -22,41 +29,87 @@ def process_utterance_group_for_async_transcription(self, utterance_ids):
 
     # The first utterance in the group will be used to keep track of failure data and attempt count
     # The other utterances will only be written to when the utterance group succeeds or fails
-    first_utterance = Utterance.objects.get(id=utterance_ids[0])
-    utterances = Utterance.objects.filter(id__in=utterance_ids).all()
+    utterances = list(Utterance.objects.filter(id__in=utterance_ids))
     if len(utterances) != len(utterance_ids):
         logger.warning(f"process_utterance_group_for_async_transcription was called for utterances {utterance_ids} but some utterances were not found, skipping")
         return
     # Make sure the utterances are in order according to the utterance ids
     utterances = sorted(utterances, key=lambda x: utterance_ids.index(x.id))
+    first_utterance = utterances[0]
 
     logger.info(f"Processing utterance group for async transcription {utterance_ids}")
 
+    # Group is fully settled — nothing to do
+    if all(u.transcription is not None or u.failure_data is not None for u in utterances):
+        logger.info(f"process_utterance_group_for_async_transcription was called for utterances {utterance_ids} but all utterances are already complete, skipping")
+        return
+
+    # If the first utterance already has failure_data, propagate to any siblings still incomplete
+    # so the group is not left half-failed forever.
     if first_utterance.failure_data:
+        incomplete = [u for u in utterances if u.transcription is None and u.failure_data is None]
+        if incomplete:
+            with transaction.atomic():
+                for utterance in incomplete:
+                    utterance.failure_data = first_utterance.failure_data
+                    utterance.save(update_fields=["failure_data"])
         logger.info(f"process_utterance_group_for_async_transcription was called for utterances {utterance_ids} but the first utterance has already failed, skipping")
         return
 
-    if first_utterance.transcription is None:
+    # Heal partial writes from a prior crash (some transcriptions saved, others not).
+    # Clear partial success so the group can be retried as a unit.
+    if any(u.transcription is not None for u in utterances):
+        logger.warning(f"Partial transcription write detected for utterances {utterance_ids}; clearing partial results for retry")
+        with transaction.atomic():
+            for utterance in utterances:
+                if utterance.transcription is not None and utterance.failure_data is None:
+                    utterance.transcription = None
+                    utterance.save(update_fields=["transcription"])
+        for utterance in utterances:
+            utterance.refresh_from_db()
+
+    try:
         first_utterance.transcription_attempt_count += 1
 
         transcriptions, failure_data = get_transcription_for_utterance_group(utterances)
 
         if failure_data:
-            if first_utterance.transcription_attempt_count < 5 and is_retryable_failure(failure_data):
+            if first_utterance.transcription_attempt_count < MAX_UTTERANCE_GROUP_ATTEMPTS and is_retryable_failure(failure_data):
                 first_utterance.save()
-                raise Exception(f"Retryable failure when transcribing utterances {utterance_ids}: {failure_data}")
-            else:
+                raise RetryableUtteranceGroupTranscriptionError(f"Retryable failure when transcribing utterances {utterance_ids}: {failure_data}")
+
+            with transaction.atomic():
                 first_utterance.save()
-                # Set the failure data for all the utterances
                 for utterance in utterances:
                     utterance.failure_data = failure_data
                     utterance.save()
-                logger.info(f"Transcription failed for utterances {utterance_ids}, failure data: {failure_data}")
-                return
+            logger.info(f"Transcription failed for utterances {utterance_ids}, failure data: {failure_data}")
+            return
 
-        # Loop through the utterances and write the transcription to the utterance
-        for utterance in utterances:
-            utterance.transcription = transcriptions[utterance.id]
-            utterance.save()
+        # Persist all transcriptions atomically so a crash cannot leave the group half-written.
+        with transaction.atomic():
+            for utterance in utterances:
+                utterance.transcription = transcriptions[utterance.id]
+                utterance.save()
 
         logger.info(f"Transcription complete for utterances {utterance_ids}")
+
+    except RetryableUtteranceGroupTranscriptionError:
+        raise
+
+    except Exception as e:
+        logger.exception(f"Unexpected failure processing utterance group {utterance_ids}: {e}")
+        # Persist attempt count so retries are bounded even if we crashed mid-save.
+        Utterance.objects.filter(id=first_utterance.id).update(transcription_attempt_count=first_utterance.transcription_attempt_count)
+
+        if first_utterance.transcription_attempt_count < MAX_UTTERANCE_GROUP_ATTEMPTS:
+            # Leave utterances incomplete (no failure_data) so Celery retry can recover.
+            raise
+
+        failure_data = {"reason": TranscriptionFailureReasons.INTERNAL_ERROR, "error": str(e)}
+        with transaction.atomic():
+            for utterance in utterances:
+                utterance.refresh_from_db()
+                utterance.failure_data = failure_data
+                utterance.save(update_fields=["failure_data"])
+        logger.info(f"Marked utterance group {utterance_ids} as failed after unexpected error")

--- a/bots/tasks/refresh_zoom_oauth_connection_task.py
+++ b/bots/tasks/refresh_zoom_oauth_connection_task.py
@@ -4,6 +4,7 @@ from django.db import transaction
 from django.utils import timezone
 
 from bots.models import ZoomOAuthConnection, ZoomOAuthConnectionStates
+from bots.redis_utils import zoom_oauth_connection_token_lock
 from bots.zoom_oauth_connections_utils import ZoomAPIAuthenticationError, ZoomAPIError, _get_access_token, _handle_zoom_api_authentication_error
 
 logger = logging.getLogger(__name__)
@@ -30,29 +31,33 @@ def enqueue_refresh_zoom_oauth_connection_task(zoom_oauth_connection: ZoomOAuthC
 def refresh_zoom_oauth_connection(self, zoom_oauth_connection_id):
     """Celery task to refresh the token for a zoom oauth connection."""
     logger.info(f"Refreshing zoom oauth connection token for zoom oauth connection {zoom_oauth_connection_id}")
-    zoom_oauth_connection = ZoomOAuthConnection.objects.get(id=zoom_oauth_connection_id)
 
-    try:
-        # Just get the access token which will refresh the refresh token
-        access_token = _get_access_token(zoom_oauth_connection)
+    # Share the same connection-scoped lock as sync/join so concurrent token rotations
+    # cannot invalidate each other with invalid_grant.
+    with zoom_oauth_connection_token_lock(zoom_oauth_connection_id):
+        zoom_oauth_connection = ZoomOAuthConnection.objects.get(id=zoom_oauth_connection_id)
 
-        if not access_token:
-            raise ZoomAPIError("No access token returned from Zoom API")
+        try:
+            # Just get the access token which will refresh the refresh token
+            access_token = _get_access_token(zoom_oauth_connection)
 
-        # Update zoom oauth connection sync success timestamp and window
-        zoom_oauth_connection.last_attempted_token_refresh_at = timezone.now()
-        zoom_oauth_connection.last_successful_token_refresh_at = zoom_oauth_connection.last_attempted_token_refresh_at
-        zoom_oauth_connection.state = ZoomOAuthConnectionStates.CONNECTED
-        zoom_oauth_connection.connection_failure_data = None
-        zoom_oauth_connection.save()
+            if not access_token:
+                raise ZoomAPIError("No access token returned from Zoom API")
 
-        logger.info(f"Successfully refreshed zoom oauth connection token for zoom oauth connection {zoom_oauth_connection_id}")
+            # Update zoom oauth connection sync success timestamp and window
+            zoom_oauth_connection.last_attempted_token_refresh_at = timezone.now()
+            zoom_oauth_connection.last_successful_token_refresh_at = zoom_oauth_connection.last_attempted_token_refresh_at
+            zoom_oauth_connection.state = ZoomOAuthConnectionStates.CONNECTED
+            zoom_oauth_connection.connection_failure_data = None
+            zoom_oauth_connection.save()
 
-    except ZoomAPIAuthenticationError as e:
-        _handle_zoom_api_authentication_error(zoom_oauth_connection, e)
+            logger.info(f"Successfully refreshed zoom oauth connection token for zoom oauth connection {zoom_oauth_connection_id}")
 
-    except Exception as e:
-        logger.exception(f"Zoom OAuth connection token refresh failed with {type(e).__name__} for {zoom_oauth_connection_id}: {e}")
-        zoom_oauth_connection.last_attempted_token_refresh_at = timezone.now()
-        zoom_oauth_connection.save()
-        raise
+        except ZoomAPIAuthenticationError as e:
+            _handle_zoom_api_authentication_error(zoom_oauth_connection, e)
+
+        except Exception as e:
+            logger.exception(f"Zoom OAuth connection token refresh failed with {type(e).__name__} for {zoom_oauth_connection_id}: {e}")
+            zoom_oauth_connection.last_attempted_token_refresh_at = timezone.now()
+            zoom_oauth_connection.save()
+            raise

--- a/bots/tasks/sync_calendar_task.py
+++ b/bots/tasks/sync_calendar_task.py
@@ -20,6 +20,7 @@ from bots.bots_api_utils import build_site_url, delete_bot, patch_bot
 from bots.calendars_api_utils import remove_bots_from_calendar
 from bots.meeting_url_utils import meeting_type_from_url
 from bots.models import Bot, BotStates, Calendar, CalendarEvent, CalendarNotificationChannel, CalendarPlatform, CalendarStates, WebhookTriggerTypes
+from bots.redis_utils import calendar_sync_lock
 from bots.webhook_payloads import calendar_webhook_payload
 from bots.webhook_utils import trigger_webhook
 
@@ -109,11 +110,15 @@ def sync_calendar(self, calendar_id):
     calendar = Calendar.objects.get(id=calendar_id)
     if calendar.platform == CalendarPlatform.GOOGLE:
         sync_handler = GoogleCalendarSyncHandler(calendar_id)
+        return sync_handler.sync_events()
     elif calendar.platform == CalendarPlatform.MICROSOFT:
-        sync_handler = MicrosoftCalendarSyncHandler(calendar_id)
+        # Microsoft rotates refresh_token on each refresh; concurrent syncs can
+        # invalidate credentials and delete SCHEDULED bots. Serialize per calendar.
+        with calendar_sync_lock(calendar_id):
+            sync_handler = MicrosoftCalendarSyncHandler(calendar_id)
+            return sync_handler.sync_events()
     else:
         raise ValueError(f"Unsupported calendar platform: {calendar.platform}")
-    return sync_handler.sync_events()
 
 
 class CalendarAPIError(Exception):
@@ -680,7 +685,11 @@ class MicrosoftCalendarSyncHandler(CalendarSyncHandler):
         Exchange the stored refresh token for a new access token.
         Microsoft returns a new refresh_token on each successful refresh.
         Persist it so we don't lose the chain.
+
+        Callers must hold calendar_sync_lock for this calendar (see sync_calendar).
         """
+        # Reload in case another refresh under the same lock rotated credentials.
+        self.calendar.refresh_from_db()
         credentials = self.calendar.get_credentials()
         if not credentials:
             raise CalendarAPIAuthenticationError("No credentials found for calendar")

--- a/bots/tasks/sync_zoom_oauth_connection_task.py
+++ b/bots/tasks/sync_zoom_oauth_connection_task.py
@@ -4,6 +4,7 @@ from django.db import transaction
 from django.utils import timezone
 
 from bots.models import ZoomOAuthConnection, ZoomOAuthConnectionStates
+from bots.redis_utils import zoom_oauth_connection_token_lock
 from bots.zoom_oauth_connections_utils import ZoomAPIAuthenticationError, _get_access_token, _get_zoom_meetings, _get_zoom_personal_meeting_id, _handle_zoom_api_authentication_error, _upsert_zoom_meeting_to_zoom_oauth_connection_mapping
 
 logger = logging.getLogger(__name__)
@@ -39,7 +40,12 @@ def sync_zoom_oauth_connection(self, zoom_oauth_connection_id):
         # Set the sync start time
         sync_started_at = timezone.now()
 
-        access_token = _get_access_token(zoom_oauth_connection)
+        # Token refresh is serialized via zoom_oauth_connection_token_lock inside
+        # _get_access_token (shared with refresh/join) so concurrent sync cannot
+        # rotate credentials out from under another worker.
+        with zoom_oauth_connection_token_lock(zoom_oauth_connection_id):
+            access_token = _get_access_token(zoom_oauth_connection)
+
         zoom_meetings = _get_zoom_meetings(access_token)
 
         logger.info(f"Fetched {len(zoom_meetings)} meetings from Zoom for zoom oauth connection {zoom_oauth_connection_id}")

--- a/bots/tests/test_async_transcription.py
+++ b/bots/tests/test_async_transcription.py
@@ -10,6 +10,7 @@ from unittest import mock
 
 from django.test import override_settings
 from django.test.testcases import TransactionTestCase
+from django.utils import timezone
 
 from bots.models import (
     AsyncTranscription,
@@ -466,6 +467,99 @@ class TestProcessUtteranceGroup(AsyncTranscriptionTestCase):
         """Verify empty utterance IDs list is handled gracefully."""
         # Should not raise
         process_utterance_group_for_async_transcription([])
+
+    @mock.patch("bots.tasks.process_utterance_group_for_async_transcription_task.get_transcription_for_utterance_group")
+    def test_partial_write_is_healed_and_retried(self, mock_get_transcription):
+        """A crash mid-save leaves partial transcriptions; retry must heal and complete the group."""
+        chunks = self._create_audio_chunks(count=3, duration_ms=1000)
+        async_transcription = AsyncTranscription.objects.create(
+            recording=self.recording,
+            settings={"transcription_settings": {"assembly_ai": {}}},
+        )
+        utterances = []
+        for chunk in chunks:
+            utterance = Utterance.objects.create(
+                recording=self.recording,
+                async_transcription=async_transcription,
+                participant=self.participant,
+                audio_chunk=chunk,
+                timestamp_ms=chunk.timestamp_ms,
+                duration_ms=chunk.duration_ms,
+            )
+            utterances.append(utterance)
+
+        # Simulate partial crash: first utterance saved, siblings incomplete
+        utterances[0].transcription = {"transcript": "partial", "words": []}
+        utterances[0].save(update_fields=["transcription"])
+
+        mock_transcriptions = {
+            utterances[0].id: {"transcript": "hello", "words": []},
+            utterances[1].id: {"transcript": "world", "words": []},
+            utterances[2].id: {"transcript": "test", "words": []},
+        }
+        mock_get_transcription.return_value = (mock_transcriptions, None)
+
+        process_utterance_group_for_async_transcription([u.id for u in utterances])
+
+        for utterance in utterances:
+            utterance.refresh_from_db()
+            self.assertIsNotNone(utterance.transcription)
+            self.assertIsNone(utterance.failure_data)
+        utterances[0].refresh_from_db()
+        self.assertEqual(utterances[0].transcription["transcript"], "hello")
+
+    @mock.patch("bots.tasks.process_utterance_group_for_async_transcription_task.get_transcription_for_utterance_group")
+    def test_unexpected_error_marks_failure_after_max_attempts(self, mock_get_transcription):
+        """Exhausted retries on unexpected errors mark the whole group failed (recoverable status)."""
+        chunks = self._create_audio_chunks(count=2, duration_ms=1000)
+        async_transcription = AsyncTranscription.objects.create(
+            recording=self.recording,
+            settings={"transcription_settings": {"assembly_ai": {}}},
+        )
+        utterances = []
+        for chunk in chunks:
+            utterance = Utterance.objects.create(
+                recording=self.recording,
+                async_transcription=async_transcription,
+                participant=self.participant,
+                audio_chunk=chunk,
+                timestamp_ms=chunk.timestamp_ms,
+                duration_ms=chunk.duration_ms,
+                transcription_attempt_count=4,  # next attempt hits max
+            )
+            utterances.append(utterance)
+
+        mock_get_transcription.side_effect = RuntimeError("boom")
+
+        process_utterance_group_for_async_transcription([u.id for u in utterances])
+
+        for utterance in utterances:
+            utterance.refresh_from_db()
+            self.assertIsNotNone(utterance.failure_data)
+            self.assertEqual(utterance.failure_data["reason"], TranscriptionFailureReasons.INTERNAL_ERROR)
+
+
+class TestProcessAsyncTranscriptionClaimRace(AsyncTranscriptionTestCase):
+    """Tests that NOT_STARTED is claimed with select_for_update."""
+
+    @mock.patch("bots.tasks.process_async_transcription_task.check_for_transcription_completion")
+    @mock.patch("bots.tasks.process_async_transcription_task.create_utterances_for_transcription")
+    def test_only_not_started_creates_utterances(self, mock_create, mock_check):
+        async_transcription = AsyncTranscription.objects.create(
+            recording=self.recording,
+            settings={"transcription_settings": {"assembly_ai": {}}},
+            state=AsyncTranscriptionStates.NOT_STARTED,
+        )
+
+        process_async_transcription(async_transcription.id)
+        mock_create.assert_called_once()
+
+        mock_create.reset_mock()
+        # After first claim path, if already IN_PROGRESS, must not create again
+        AsyncTranscription.objects.filter(id=async_transcription.id).update(state=AsyncTranscriptionStates.IN_PROGRESS, started_at=timezone.now())
+        process_async_transcription(async_transcription.id)
+        mock_create.assert_not_called()
+        mock_check.assert_called()
 
 
 @override_settings(CELERY_TASK_ALWAYS_EAGER=True, CELERY_TASK_EAGER_PROPAGATES=True)

--- a/bots/tests/test_redis_utils.py
+++ b/bots/tests/test_redis_utils.py
@@ -4,7 +4,13 @@ import redis
 from django.conf import settings
 from django.test import TestCase
 
-from bots.redis_utils import incr_and_expire_nx
+from bots.redis_utils import (
+    calendar_sync_lock_key,
+    incr_and_expire_nx,
+    redis_lock,
+    zoom_oauth_connection_token_lock,
+    zoom_oauth_connection_token_lock_key,
+)
 
 
 class IncrAndExpireNxTest(TestCase):
@@ -37,3 +43,32 @@ class IncrAndExpireNxTest(TestCase):
         incr_and_expire_nx(self.redis_client, self.test_key, ttl=1)
         time.sleep(1.5)
         self.assertIsNone(self.redis_client.get(self.test_key))
+
+
+class RedisLockTest(TestCase):
+    def setUp(self):
+        self.redis_client = redis.from_url(settings.REDIS_URL_WITH_PARAMS)
+        self.lock_key = f"test_redis_lock:{time.time()}"
+
+    def tearDown(self):
+        self.redis_client.delete(self.lock_key)
+        self.redis_client.close()
+
+    def test_redis_lock_is_reentrant_for_same_key(self):
+        entered_inner = False
+        with redis_lock(self.lock_key, timeout=10, blocking_timeout=5):
+            with redis_lock(self.lock_key, timeout=10, blocking_timeout=5):
+                entered_inner = True
+        self.assertTrue(entered_inner)
+
+    def test_zoom_and_calendar_lock_keys_are_stable(self):
+        self.assertEqual(zoom_oauth_connection_token_lock_key(42), "lock:zoom-oauth-connection-token:42")
+        self.assertEqual(calendar_sync_lock_key(7), "lock:calendar-sync:7")
+
+    def test_zoom_oauth_connection_token_lock_acquires_redis_key(self):
+        connection_id = int(time.time() * 1000) % 1000000
+        lock_key = zoom_oauth_connection_token_lock_key(connection_id)
+        with zoom_oauth_connection_token_lock(connection_id, timeout=10, blocking_timeout=5):
+            # Lock key exists while held (redis-py lock uses the key directly)
+            self.assertTrue(self.redis_client.exists(lock_key))
+        self.redis_client.delete(lock_key)

--- a/bots/tests/test_refresh_zoom_oauth_connection_task.py
+++ b/bots/tests/test_refresh_zoom_oauth_connection_task.py
@@ -1,3 +1,4 @@
+from contextlib import contextmanager
 from unittest.mock import patch
 
 from django.test import TestCase
@@ -16,6 +17,11 @@ from bots.tasks.refresh_zoom_oauth_connection_task import (
 from bots.zoom_oauth_connections_utils import ZoomAPIAuthenticationError
 
 
+@contextmanager
+def _noop_lock(*args, **kwargs):
+    yield
+
+
 class TestRefreshZoomOAuthConnection(TestCase):
     """Test the refresh_zoom_oauth_connection Celery task."""
 
@@ -30,6 +36,14 @@ class TestRefreshZoomOAuthConnection(TestCase):
             account_id="test_account_id",
         )
         self.zoom_oauth_connection.set_credentials({"refresh_token": "test_refresh_token"})
+        self.lock_patcher = patch(
+            "bots.tasks.refresh_zoom_oauth_connection_task.zoom_oauth_connection_token_lock",
+            side_effect=_noop_lock,
+        )
+        self.lock_patcher.start()
+
+    def tearDown(self):
+        self.lock_patcher.stop()
 
     @patch("bots.tasks.refresh_zoom_oauth_connection_task._get_access_token")
     def test_refresh_zoom_oauth_connection_success(self, mock_get_access_token):
@@ -45,6 +59,18 @@ class TestRefreshZoomOAuthConnection(TestCase):
         self.assertIsNotNone(self.zoom_oauth_connection.last_attempted_token_refresh_at)
         self.assertIsNotNone(self.zoom_oauth_connection.last_successful_token_refresh_at)
         self.assertIsNone(self.zoom_oauth_connection.connection_failure_data)
+
+    @patch("bots.tasks.refresh_zoom_oauth_connection_task._get_access_token")
+    @patch("bots.tasks.refresh_zoom_oauth_connection_task.zoom_oauth_connection_token_lock")
+    def test_refresh_acquires_connection_scoped_lock(self, mock_lock, mock_get_access_token):
+        """Refresh must take the connection token lock before rotating credentials."""
+        mock_lock.side_effect = _noop_lock
+        mock_get_access_token.return_value = "mock_access_token"
+
+        refresh_zoom_oauth_connection(self.zoom_oauth_connection.id)
+
+        mock_lock.assert_called_with(self.zoom_oauth_connection.id)
+
 
     @patch("bots.zoom_oauth_connections_utils.trigger_webhook")
     @patch("bots.tasks.refresh_zoom_oauth_connection_task._get_access_token")

--- a/bots/tests/test_sync_calendar_task.py
+++ b/bots/tests/test_sync_calendar_task.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timedelta
 from datetime import timezone as python_timezone
+from contextlib import contextmanager
 from unittest.mock import Mock, patch
 
 import requests
@@ -31,6 +32,11 @@ from bots.tasks.sync_calendar_task import (
     sync_calendar,
 )
 from bots.webhook_payloads import calendar_webhook_payload
+
+
+@contextmanager
+def _calendar_noop_lock(*args, **kwargs):
+    yield
 
 
 class TestExtractMeetingUrlFromText(TestCase):
@@ -288,8 +294,10 @@ class TestSyncCalendar(TestCase):
         self.assertEqual(result, {"success": True})
 
     @patch("bots.tasks.sync_calendar_task.MicrosoftCalendarSyncHandler")
-    def test_sync_calendar_microsoft(self, mock_handler_class):
+    @patch("bots.tasks.sync_calendar_task.calendar_sync_lock")
+    def test_sync_calendar_microsoft(self, mock_lock, mock_handler_class):
         """Test sync_calendar task creates MicrosoftCalendarSyncHandler for Microsoft calendar."""
+        mock_lock.side_effect = lambda *args, **kwargs: _calendar_noop_lock()
         calendar = Calendar.objects.create(project=self.project, platform=CalendarPlatform.MICROSOFT, client_id="test_client_id")
         mock_handler = Mock()
         mock_handler.sync_events.return_value = {"success": True}
@@ -297,6 +305,7 @@ class TestSyncCalendar(TestCase):
 
         result = sync_calendar(calendar.id)
 
+        mock_lock.assert_called_with(calendar.id)
         mock_handler_class.assert_called_once_with(calendar.id)
         mock_handler.sync_events.assert_called_once()
         self.assertEqual(result, {"success": True})
@@ -979,6 +988,15 @@ class TestMicrosoftNotificationChannelLifecycle(TransactionTestCase):
 
         settings.CELERY_TASK_ALWAYS_EAGER = True
         settings.CELERY_TASK_EAGER_PROPAGATES = True
+        self.lock_patcher = patch(
+            "bots.tasks.sync_calendar_task.calendar_sync_lock",
+            side_effect=_calendar_noop_lock,
+        )
+        self.lock_patcher.start()
+
+    def tearDown(self):
+        self.lock_patcher.stop()
+        super().tearDown()
 
     @patch("bots.tasks.sync_calendar_task.MicrosoftCalendarSyncHandler._list_events")
     @patch("bots.tasks.sync_calendar_task.MicrosoftCalendarSyncHandler._get_event_by_id")

--- a/bots/tests/test_sync_zoom_oauth_connection_task.py
+++ b/bots/tests/test_sync_zoom_oauth_connection_task.py
@@ -1,3 +1,4 @@
+from contextlib import contextmanager
 from datetime import timedelta
 from unittest.mock import Mock, patch
 
@@ -19,6 +20,11 @@ from bots.tasks.sync_zoom_oauth_connection_task import (
 from bots.zoom_oauth_connections_utils import ZoomAPIAuthenticationError
 
 
+@contextmanager
+def _noop_lock(*args, **kwargs):
+    yield
+
+
 class TestSyncZoomOAuthConnection(TestCase):
     """Test the sync_zoom_oauth_connection Celery task."""
 
@@ -33,6 +39,28 @@ class TestSyncZoomOAuthConnection(TestCase):
             account_id="test_account_id",
         )
         self.zoom_oauth_connection.set_credentials({"refresh_token": "test_refresh_token"})
+        self.lock_patcher = patch(
+            "bots.tasks.sync_zoom_oauth_connection_task.zoom_oauth_connection_token_lock",
+            side_effect=_noop_lock,
+        )
+        self.lock_patcher.start()
+
+    def tearDown(self):
+        self.lock_patcher.stop()
+
+    @patch("bots.tasks.sync_zoom_oauth_connection_task._get_access_token")
+    @patch("bots.tasks.sync_zoom_oauth_connection_task.zoom_oauth_connection_token_lock")
+    def test_sync_acquires_connection_scoped_lock(self, mock_lock, mock_get_access_token):
+        """Sync must share the same connection token lock as refresh."""
+        mock_lock.side_effect = _noop_lock
+        mock_get_access_token.return_value = "mock_access_token"
+
+        with patch("bots.tasks.sync_zoom_oauth_connection_task._get_zoom_meetings", return_value=[]):
+            with patch("bots.tasks.sync_zoom_oauth_connection_task._get_zoom_personal_meeting_id", return_value="pmi"):
+                with patch("bots.tasks.sync_zoom_oauth_connection_task._upsert_zoom_meeting_to_zoom_oauth_connection_mapping"):
+                    sync_zoom_oauth_connection(self.zoom_oauth_connection.id)
+
+        mock_lock.assert_called_with(self.zoom_oauth_connection.id)
 
     @patch("bots.tasks.sync_zoom_oauth_connection_task._upsert_zoom_meeting_to_zoom_oauth_connection_mapping")
     @patch("bots.tasks.sync_zoom_oauth_connection_task._get_zoom_personal_meeting_id")
@@ -200,6 +228,14 @@ class TestGetAccessToken(TestCase):
             account_id="test_account_id",
         )
         self.zoom_oauth_connection.set_credentials({"refresh_token": "test_refresh_token"})
+        self.lock_patcher = patch(
+            "bots.redis_utils.zoom_oauth_connection_token_lock",
+            side_effect=_noop_lock,
+        )
+        self.lock_patcher.start()
+
+    def tearDown(self):
+        self.lock_patcher.stop()
 
     @patch("requests.post")
     def test_get_access_token_success(self, mock_post):
@@ -215,6 +251,28 @@ class TestGetAccessToken(TestCase):
 
         self.assertEqual(result, "new_access_token")
         mock_post.assert_called_once()
+
+    @patch("requests.post")
+    @patch("bots.redis_utils.zoom_oauth_connection_token_lock")
+    def test_get_access_token_takes_lock_and_reloads_credentials(self, mock_lock, mock_post):
+        """Token refresh must lock the connection and reload credentials under the lock."""
+        from bots.zoom_oauth_connections_utils import _get_access_token
+
+        mock_lock.side_effect = _noop_lock
+        mock_response = Mock()
+        mock_response.json.return_value = {
+            "access_token": "new_access_token",
+            "refresh_token": "rotated_refresh_token",
+        }
+        mock_response.raise_for_status.return_value = None
+        mock_post.return_value = mock_response
+
+        result = _get_access_token(self.zoom_oauth_connection)
+
+        mock_lock.assert_called_with(self.zoom_oauth_connection.id)
+        self.assertEqual(result, "new_access_token")
+        self.zoom_oauth_connection.refresh_from_db()
+        self.assertEqual(self.zoom_oauth_connection.get_credentials()["refresh_token"], "rotated_refresh_token")
 
     @patch("requests.post")
     def test_get_access_token_with_refresh_token_rotation(self, mock_post):

--- a/bots/zoom_oauth_connections_utils.py
+++ b/bots/zoom_oauth_connections_utils.py
@@ -91,45 +91,54 @@ def _get_access_token(zoom_oauth_connection) -> str:
     Exchange the stored refresh token for a new access token.
     Zoom returns a new refresh_token on each successful refresh.
     Persist it so we don't lose the chain.
+
+    Concurrent refreshes are serialized with a Redis lock keyed by connection id
+    so a second worker waits and then uses the rotated token instead of racing
+    into invalid_grant.
     """
-    credentials = zoom_oauth_connection.get_credentials()
-    if not credentials:
-        raise ZoomAPIAuthenticationError("No credentials found for zoom oauth connection")
+    from bots.redis_utils import zoom_oauth_connection_token_lock
 
-    refresh_token = credentials.get("refresh_token")
-    client_id = zoom_oauth_connection.zoom_oauth_app.client_id
-    client_secret = zoom_oauth_connection.zoom_oauth_app.client_secret
-    if not refresh_token or not client_id or not client_secret:
-        raise ZoomAPIAuthenticationError("Missing refresh_token or client_secret")
+    with zoom_oauth_connection_token_lock(zoom_oauth_connection.id):
+        # Reload credentials after acquiring the lock — a prior refresher may have rotated them.
+        zoom_oauth_connection.refresh_from_db()
+        credentials = zoom_oauth_connection.get_credentials()
+        if not credentials:
+            raise ZoomAPIAuthenticationError("No credentials found for zoom oauth connection")
 
-    data = {
-        "grant_type": "refresh_token",
-        "refresh_token": refresh_token,
-        "client_id": client_id,
-        "client_secret": client_secret,
-    }
+        refresh_token = credentials.get("refresh_token")
+        client_id = zoom_oauth_connection.zoom_oauth_app.client_id
+        client_secret = zoom_oauth_connection.zoom_oauth_app.client_secret
+        if not refresh_token or not client_id or not client_secret:
+            raise ZoomAPIAuthenticationError("Missing refresh_token or client_secret")
 
-    try:
-        response = requests.post("https://zoom.us/oauth/token", data=data, timeout=30)
-        response.raise_for_status()
-        token_data = response.json()
+        data = {
+            "grant_type": "refresh_token",
+            "refresh_token": refresh_token,
+            "client_id": client_id,
+            "client_secret": client_secret,
+        }
 
-        access_token = token_data.get("access_token")
-        if not access_token:
-            raise ZoomAPIError(f"No access_token in refresh response. Response body: {response.json()}")
+        try:
+            response = requests.post("https://zoom.us/oauth/token", data=data, timeout=30)
+            response.raise_for_status()
+            token_data = response.json()
 
-        # IMPORTANT: Zoom rotates refresh tokens. Save the new one if provided.
-        new_refresh = token_data.get("refresh_token")
-        if new_refresh and new_refresh != refresh_token:
-            credentials["refresh_token"] = new_refresh
-            zoom_oauth_connection.set_credentials(credentials)
-            logger.info("Stored rotated Zoom refresh_token for zoom oauth connection %s", zoom_oauth_connection.object_id)
+            access_token = token_data.get("access_token")
+            if not access_token:
+                raise ZoomAPIError(f"No access_token in refresh response. Response body: {response.json()}")
 
-        return access_token
+            # IMPORTANT: Zoom rotates refresh tokens. Save the new one if provided.
+            new_refresh = token_data.get("refresh_token")
+            if new_refresh and new_refresh != refresh_token:
+                credentials["refresh_token"] = new_refresh
+                zoom_oauth_connection.set_credentials(credentials)
+                logger.info("Stored rotated Zoom refresh_token for zoom oauth connection %s", zoom_oauth_connection.object_id)
 
-    except requests.RequestException as e:
-        _raise_if_error_is_authentication_error(e)
-        raise ZoomAPIError(f"Failed to refresh Zoom access token. Response body: {e.response.json()}")
+            return access_token
+
+        except requests.RequestException as e:
+            _raise_if_error_is_authentication_error(e)
+            raise ZoomAPIError(f"Failed to refresh Zoom access token. Response body: {e.response.json()}")
 
 
 def _make_zoom_api_request(url: str, access_token: str, params: dict) -> dict:


### PR DESCRIPTION
## Summary
- **Zoom OAuth**: Redis lock `lock:zoom-oauth-connection-token:{id}` serializes token refresh in `_get_access_token` (shared by refresh/sync/join).
- **Microsoft calendar sync**: Redis lock `lock:calendar-sync:{id}` around full sync.
- **Async transcription**: `select_for_update` when claiming `NOT_STARTED`; utterance-group saves in `transaction.atomic` with heal + terminal failure.

## Test plan

Local (Mimir): Postgres 15.3 + Redis 7.

- [x] Refresh/sync OAuth + calendar + async transcription + utterance + validate — **224/224 OK**
- [x] `bots.tests.test_redis_utils` — **7/7 OK** (reentrant lock helpers)

**Still for CI:** full Docker matrix on this PR.


---
Contribution from [Cold Code Labs](https://github.com/cold-code-labs) · authored via Brokk · co-authors in commit trailers.
