### PR TITLE
chore(deps): bump pyasn1, cryptography, and msgpack for advisories

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ click==8.1.7
 click-didyoumean==0.3.1
 click-plugins==1.1.1
 click-repl==0.3.0
-cryptography==48.0.1
+cryptography==50.0.0
 dj-database-url==2.3.0
 Django==5.1.14
 django-allauth==65.1.0
@@ -81,7 +81,7 @@ grpcio==1.70.0
 grpcio-status==1.70.0
 proto-plus==1.26.0
 protobuf==5.29.6
-pyasn1==0.6.2
+pyasn1==0.6.4
 pyasn1_modules==0.4.1
 rsa==4.9
 ruff==0.9.6
@@ -92,7 +92,7 @@ tldextract==5.3.0
 aiortc==1.10.1
 deepgram-sdk==4.3.0
 docker==7.1.0
-msgpack==1.1.0
+msgpack==1.2.1
 azure-identity==1.25.1
 azure-storage-blob==12.26.0
 python-json-logger==4.0.0


### PR DESCRIPTION
## Summary
- `pyasn1` 0.6.2 → 0.6.4
- `cryptography` 48.0.1 → 50.0.0
- `msgpack` 1.1.0 → 1.2.1
- Django left for open PR #937

Requirements-only.

## Test plan

Local (Mimir):

- [x] Fresh venv `pip install -r requirements.txt` with `cryptography==50.0.0`, `pyasn1==0.6.4`, `msgpack==1.2.1` — OK
- [x] `pip check` clean (incl. `pyOpenSSL` 26.4 pulled by `aiortc`)
- [x] Imports report expected versions; Django remains `5.1.14`

**Still for CI:** full `manage.py test` matrix in Docker image (host lacks `gi`/GStreamer for `manage.py check` outside the image).


---
Contribution from [Cold Code Labs](https://github.com/cold-code-labs) · authored via Brokk · co-authors in commit trailers.
