### PR TITLE
Support configuring database via separate POSTGRES_* env vars

### DIFF
--- a/attendee/settings/db.py
+++ b/attendee/settings/db.py
@@ -1,0 +1,36 @@
+import os
+from urllib.parse import quote
+
+import dj_database_url
+from django.core.exceptions import ImproperlyConfigured
+
+POSTGRES_ENV_VARS = ("POSTGRES_HOST", "POSTGRES_DB", "POSTGRES_USER")
+
+
+def _database_url_from_postgres_env():
+    # DATABASE_URL takes precedence; these vars are only consulted when it's unset.
+    host = os.getenv("POSTGRES_HOST")
+    name = os.getenv("POSTGRES_DB")
+    user = os.getenv("POSTGRES_USER")
+    if not (host and name and user):
+        return None
+    password = os.getenv("POSTGRES_PASSWORD", "")
+    port = os.getenv("POSTGRES_PORT", "5432")
+    auth = quote(user, safe="")
+    if password:
+        auth += ":" + quote(password, safe="")
+    return f"postgresql://{auth}@{host}:{port}/{quote(name, safe='')}"
+
+
+def default_database(ssl_require):
+    url = os.getenv("DATABASE_URL") or _database_url_from_postgres_env()
+    if not url:
+        raise ImproperlyConfigured("Database is not configured. Set DATABASE_URL, or set " + ", ".join(POSTGRES_ENV_VARS) + " (and optionally POSTGRES_PASSWORD, POSTGRES_PORT).")
+    return dj_database_url.parse(
+        url,
+        conn_max_age=600,
+        conn_health_checks=True,
+        ssl_require=ssl_require,
+        # Set to "true" behind a transaction-pooling pooler (PgBouncer, etc.).
+        disable_server_side_cursors=os.getenv("DISABLE_SERVER_SIDE_CURSORS", "false") == "true",
+    )

--- a/attendee/settings/production-gke.py
+++ b/attendee/settings/production-gke.py
@@ -1,22 +1,14 @@
 import os
 
-import dj_database_url
-
 from .base import *
 from .base import LOG_FORMATTERS, LOG_HANDLER_NAMES, LOG_HANDLERS
+from .db import default_database
 
 DEBUG = False
 ALLOWED_HOSTS = os.getenv("ALLOWED_HOSTS", "*").split(",")
 
 DATABASES = {
-    "default": dj_database_url.config(
-        env="DATABASE_URL",
-        conn_max_age=600,
-        conn_health_checks=True,
-        ssl_require=True,
-        # Set to "true" behind a transaction-pooling pooler (PgBouncer, etc.).
-        disable_server_side_cursors=os.getenv("DISABLE_SERVER_SIDE_CURSORS", "false") == "true",
-    ),
+    "default": default_database(ssl_require=True),
 }
 
 # PRESERVE CELERY TASKS IF WORKER IS SHUT DOWN

--- a/attendee/settings/production.py
+++ b/attendee/settings/production.py
@@ -1,22 +1,14 @@
 import os
 
-import dj_database_url
-
 from .base import *
 from .base import LOG_FORMATTERS, LOG_HANDLER_NAMES, LOG_HANDLERS
+from .db import default_database
 
 DEBUG = False
 ALLOWED_HOSTS = os.getenv("ALLOWED_HOSTS", "*").split(",")
 
 DATABASES = {
-    "default": dj_database_url.config(
-        env="DATABASE_URL",
-        conn_max_age=600,
-        conn_health_checks=True,
-        ssl_require=os.getenv("POSTGRES_SSL_REQUIRE", "true") == "true",
-        # Set to "true" behind a transaction-pooling pooler (PgBouncer, etc.).
-        disable_server_side_cursors=os.getenv("DISABLE_SERVER_SIDE_CURSORS", "false") == "true",
-    ),
+    "default": default_database(ssl_require=os.getenv("POSTGRES_SSL_REQUIRE", "true") == "true"),
 }
 
 # PRESERVE CELERY TASKS IF WORKER IS SHUT DOWN

--- a/attendee/settings/staging-gke.py
+++ b/attendee/settings/staging-gke.py
@@ -1,22 +1,14 @@
 import os
 
-import dj_database_url
-
 from .base import *
 from .base import LOG_FORMATTERS, LOG_HANDLER_NAMES, LOG_HANDLERS
+from .db import default_database
 
 DEBUG = False
 ALLOWED_HOSTS = os.getenv("ALLOWED_HOSTS", "*").split(",")
 
 DATABASES = {
-    "default": dj_database_url.config(
-        env="DATABASE_URL",
-        conn_max_age=600,
-        conn_health_checks=True,
-        ssl_require=True,
-        # Set to "true" behind a transaction-pooling pooler (PgBouncer, etc.).
-        disable_server_side_cursors=os.getenv("DISABLE_SERVER_SIDE_CURSORS", "false") == "true",
-    ),
+    "default": default_database(ssl_require=True),
 }
 
 # PRESERVE CELERY TASKS IF WORKER IS SHUT DOWN

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -33,9 +33,15 @@ This document lists all supported environment variables for the Attendee applica
 
 | Variable | Type | Default | Description |
 |----------|------|---------|-------------|
-| `DATABASE_URL` | String | **Required** | PostgreSQL database connection URL (format: `postgresql://user:password@host:port/database`). |
+| `DATABASE_URL` | String | **Required*** | PostgreSQL database connection URL (format: `postgresql://user:password@host:port/database`). Takes precedence over the individual `POSTGRES_*` variables below. |
 | `POSTGRES_SSL_REQUIRE` | Boolean | `true` | Require SSL/TLS connection to PostgreSQL. Set to `false` for local development. |
-| `POSTGRES_HOST` | String | `localhost` | PostgreSQL host for development environments. Only used if not specified in `DATABASE_URL`. |
+| `POSTGRES_HOST` | String | `localhost` | PostgreSQL host. Alternative to `DATABASE_URL` together with the other `POSTGRES_*` variables; also used for development environments. |
+| `POSTGRES_PORT` | String | `5432` | PostgreSQL port. Only used when connecting via the `POSTGRES_*` variables. |
+| `POSTGRES_DB` | String | — | PostgreSQL database name. Required when connecting via the `POSTGRES_*` variables. |
+| `POSTGRES_USER` | String | — | PostgreSQL user. Required when connecting via the `POSTGRES_*` variables. |
+| `POSTGRES_PASSWORD` | String | — | PostgreSQL password. Only used when connecting via the `POSTGRES_*` variables. |
+
+\* Either `DATABASE_URL` or the set of `POSTGRES_HOST`, `POSTGRES_DB` and `POSTGRES_USER` (plus `POSTGRES_PASSWORD`/`POSTGRES_PORT` as needed) must be provided.
 
 ---
 


### PR DESCRIPTION
## Summary

Allows configuring the production/staging database connection with individual environment variables as an alternative to a full `DATABASE_URL`:

- `POSTGRES_HOST` (required for this mode)
- `POSTGRES_DB` (required for this mode)
- `POSTGRES_USER` (required for this mode)
- `POSTGRES_PASSWORD` (optional)
- `POSTGRES_PORT` (optional, defaults to `5432`)

This is useful when credentials are injected as separate secrets (e.g. Kubernetes secrets, Cloud SQL, various secret managers) and composing a full connection URL is awkward.

## Backwards compatibility

`DATABASE_URL` still takes precedence whenever it is set, so existing deployments are unaffected. The individual variables are only consulted when `DATABASE_URL` is unset.

## Changes

- New `attendee/settings/db.py` with a shared `default_database(ssl_require)` helper that builds the connection from `DATABASE_URL` or the `POSTGRES_*` vars. Credentials and database name are URL-escaped, so passwords with special characters work. If neither form is configured, it raises `ImproperlyConfigured` with a clear message instead of failing later with an empty database config.
- `production.py`, `production-gke.py` and `staging-gke.py` now use the shared helper instead of three duplicated `dj_database_url.config(...)` blocks. Per-environment behavior is unchanged (`POSTGRES_SSL_REQUIRE`-driven SSL in `production.py`, always-required SSL in the GKE settings, `DISABLE_SERVER_SIDE_CURSORS`, `conn_max_age=600`, health checks).
- Documented the new variables in `docs/environment-variables.md`.

## Testing

Verified the helper in isolation: the `POSTGRES_*` fallback produces the expected Django config (including `sslmode=require` and special characters in passwords round-tripping correctly), `DATABASE_URL` wins when both are present, and a missing configuration raises the explicit error.