### PR TITLE
Delete debug files when deleting bot data

### DIFF
--- a/bots/bot_controller/bot_controller.py
+++ b/bots/bot_controller/bot_controller.py
@@ -1681,11 +1681,13 @@ class BotController:
         # Find the bot's last event
         last_bot_event = self.bot_in_db.last_bot_event()
         if last_bot_event:
-            debug_screenshot = BotDebugScreenshot.objects.create(bot_event=last_bot_event)
-
             # Save the file directly from the file path
             with open(BotAdapter.DEBUG_RECORDING_FILE_PATH, "rb") as f:
-                debug_screenshot.file.save(f"debug_screen_recording_{debug_screenshot.object_id}.mp4", f, save=True)
+                debug_screenshot = BotDebugScreenshot.create_with_file(
+                    bot_event=last_bot_event,
+                    filename_template="debug_screen_recording_{object_id}.mp4",
+                    content=f,
+                )
             logger.info(f"Saved debug recording with ID {debug_screenshot.object_id}")
 
     def save_bot_pod_logs(self):
@@ -1718,9 +1720,12 @@ class BotController:
             return
 
         for part_number, path in enumerate(log_file_paths_in_order, start=1):
-            debug_screenshot = BotDebugScreenshot.objects.create(bot_event=last_bot_event)
             with open(path, "rb") as f:
-                debug_screenshot.file.save(f"bot_logs_part_{part_number}_{debug_screenshot.object_id}.log", f, save=True)
+                debug_screenshot = BotDebugScreenshot.create_with_file(
+                    bot_event=last_bot_event,
+                    filename_template=f"bot_logs_part_{part_number}_{{object_id}}.log",
+                    content=f,
+                )
             logger.info(f"Saved bot pod logs from {path} with ID {debug_screenshot.object_id}")
 
     def on_message_from_websocket_audio(self, message_json: str):
@@ -1761,16 +1766,13 @@ class BotController:
                 logger.warning(f"Warning: Screenshot file at {message.get('screenshot_path')} does not exist, not saving")
                 return
 
-            # Create debug screenshot
-            debug_screenshot = BotDebugScreenshot.objects.create(bot_event=new_bot_event)
-
             # Read the file content from the path
             with open(message.get("screenshot_path"), "rb") as f:
                 screenshot_content = f.read()
-                debug_screenshot.file.save(
-                    f"debug_screenshot_{debug_screenshot.object_id}.png",
-                    ContentFile(screenshot_content),
-                    save=True,
+                BotDebugScreenshot.create_with_file(
+                    bot_event=new_bot_event,
+                    filename_template="debug_screenshot_{object_id}.png",
+                    content=ContentFile(screenshot_content),
                 )
 
         if mhtml_file_available:
@@ -1778,15 +1780,12 @@ class BotController:
                 logger.warning(f"Warning: MHTML file at {message.get('mhtml_file_path')} does not exist, not saving")
                 return
 
-            # Create debug screenshot
-            mhtml_debug_screenshot = BotDebugScreenshot.objects.create(bot_event=new_bot_event)
-
             with open(message.get("mhtml_file_path"), "rb") as f:
                 mhtml_content = f.read()
-                mhtml_debug_screenshot.file.save(
-                    f"debug_screenshot_{mhtml_debug_screenshot.object_id}.mhtml",
-                    ContentFile(mhtml_content),
-                    save=True,
+                BotDebugScreenshot.create_with_file(
+                    bot_event=new_bot_event,
+                    filename_template="debug_screenshot_{object_id}.mhtml",
+                    content=ContentFile(mhtml_content),
                 )
 
     def take_action_based_on_message_from_adapter(self, message):
@@ -1926,28 +1925,22 @@ class BotController:
             logger.info(f"Created bot event for #{self.bot_in_db.object_id} for UI element not found. Exception info: {message}")
 
             if screenshot_available:
-                # Create debug screenshot
-                debug_screenshot = BotDebugScreenshot.objects.create(bot_event=new_bot_event)
-
                 # Read the file content from the path
                 with open(message.get("screenshot_path"), "rb") as f:
                     screenshot_content = f.read()
-                    debug_screenshot.file.save(
-                        f"debug_screenshot_{debug_screenshot.object_id}.png",
-                        ContentFile(screenshot_content),
-                        save=True,
+                    BotDebugScreenshot.create_with_file(
+                        bot_event=new_bot_event,
+                        filename_template="debug_screenshot_{object_id}.png",
+                        content=ContentFile(screenshot_content),
                     )
 
             if mhtml_file_available:
-                # Create debug screenshot
-                mhtml_debug_screenshot = BotDebugScreenshot.objects.create(bot_event=new_bot_event)
-
                 with open(message.get("mhtml_file_path"), "rb") as f:
                     mhtml_content = f.read()
-                    mhtml_debug_screenshot.file.save(
-                        f"debug_screenshot_{mhtml_debug_screenshot.object_id}.mhtml",
-                        ContentFile(mhtml_content),
-                        save=True,
+                    BotDebugScreenshot.create_with_file(
+                        bot_event=new_bot_event,
+                        filename_template="debug_screenshot_{object_id}.mhtml",
+                        content=ContentFile(mhtml_content),
                     )
 
             self.cleanup()

--- a/bots/models.py
+++ b/bots/models.py
@@ -872,17 +872,27 @@ class Bot(models.Model):
     session_type = models.IntegerField(choices=SessionTypes.choices, default=SessionTypes.BOT, db_default=SessionTypes.BOT, null=False)
 
     def delete_data(self):
-        # Check if bot is in a state where the data deleted event can be created
-        if not BotEventManager.event_can_be_created_for_state(BotEventTypes.DATA_DELETED, self.state):
-            raise ValueError("Bot is not in a state where the data deleted event can be created")
-
+        # Object storage operations cannot roll back with the database. A
+        # failure leaves the bot in its previous state, and supported storage
+        # backends make deletes idempotent so a retry converges safely.
         with transaction.atomic():
+            # Serialize data deletion with debug artifact creation. This prevents
+            # cleanup from uploading a new artifact after the deletion sweep.
+            # The lock intentionally spans storage I/O: delete_data must not
+            # report success while a cleanup upload for the same bot is active.
+            Bot.objects.select_for_update().only("pk").get(pk=self.pk)
+            self.refresh_from_db()
+
+            data_was_already_deleted = self.state == BotStates.DATA_DELETED
+            if not data_was_already_deleted and not BotEventManager.event_can_be_created_for_state(BotEventTypes.DATA_DELETED, self.state):
+                raise ValueError("Bot is not in a state where the data deleted event can be created")
+
             # Delete all debug screenshots from bot events
-            debug_screenshots = BotDebugScreenshot.objects.filter(bot_event__bot=self)
+            debug_screenshots = list(BotDebugScreenshot.objects.filter(bot_event__bot=self).only("pk", "file"))
             for debug_screenshot in debug_screenshots:
                 if debug_screenshot.file and debug_screenshot.file.name:
-                    debug_screenshot.file.delete()
-            debug_screenshots.delete()
+                    debug_screenshot.file.delete(save=False)
+            BotDebugScreenshot.objects.filter(pk__in=[debug_screenshot.pk for debug_screenshot in debug_screenshots]).delete()
 
             # Delete all utterances and recording files for each recording
             for recording in self.recordings.all():
@@ -904,7 +914,8 @@ class Bot(models.Model):
             webhook_delivery_attempts_with_sensitive_data = self.webhook_delivery_attempts.exclude(webhook_trigger_type=WebhookTriggerTypes.BOT_STATE_CHANGE)
             webhook_delivery_attempts_with_sensitive_data.delete()
 
-            BotEventManager.create_event(bot=self, event_type=BotEventTypes.DATA_DELETED)
+            if not data_was_already_deleted:
+                BotEventManager.create_event(bot=self, event_type=BotEventTypes.DATA_DELETED)
 
     def set_heartbeat(self):
         retry_count = 0
@@ -3039,12 +3050,45 @@ class BotDebugScreenshot(models.Model):
     file = models.FileField(storage=BotDebugScreenshotStorage())
     created_at = models.DateTimeField(auto_now_add=True)
 
-    def save(self, *args, **kwargs):
+    @classmethod
+    def create_with_file(cls, *, bot_event, filename_template, content):
+        """Create a debug artifact while serialized with bot data deletion."""
+        with transaction.atomic():
+            bot = Bot.objects.select_for_update().only("state", "object_id").get(pk=bot_event.bot_id)
+            if bot.state == BotStates.DATA_DELETED:
+                raise ValueError(f"Cannot create a debug artifact after data was deleted for bot {bot.object_id}")
+
+            # The bot lock is already held for this complete operation, so use
+            # the unguarded model save to avoid redundant SELECT FOR UPDATEs.
+            artifact = cls(bot_event=bot_event)
+            artifact._save_without_data_deletion_guard()
+            artifact.file.save(filename_template.format(object_id=artifact.object_id), content, save=False)
+            artifact._save_without_data_deletion_guard(update_fields=["file"])
+            return artifact
+
+    def _save_without_data_deletion_guard(self, *args, **kwargs):
         if not self.object_id:
             # Generate a random 16-character string
             random_string = "".join(secrets.choice(string.ascii_letters + string.digits) for _ in range(16))
             self.object_id = f"{self.OBJECT_ID_PREFIX}{random_string}"
         super().save(*args, **kwargs)
+
+    def save(self, *args, **kwargs):
+        with transaction.atomic():
+            if "bot_event" in self._state.fields_cache:
+                bot_id = self.bot_event.bot_id
+            else:
+                bot_id = BotEvent.objects.values_list("bot_id", flat=True).get(pk=self.bot_event_id)
+
+            bot = Bot.objects.select_for_update().only("state", "object_id").get(pk=bot_id)
+            if bot.state == BotStates.DATA_DELETED:
+                # FieldFile.save() uploads before saving the model. Delete that
+                # just-uploaded object when a direct caller races with deletion.
+                if self.file and self.file.name and self.file._committed:
+                    self.file.delete(save=False)
+                raise ValueError(f"Cannot save a debug artifact after data was deleted for bot {bot.object_id}")
+
+            self._save_without_data_deletion_guard(*args, **kwargs)
 
     @property
     def url(self):

--- a/bots/models.py
+++ b/bots/models.py
@@ -878,7 +878,11 @@ class Bot(models.Model):
 
         with transaction.atomic():
             # Delete all debug screenshots from bot events
-            BotDebugScreenshot.objects.filter(bot_event__bot=self).delete()
+            debug_screenshots = BotDebugScreenshot.objects.filter(bot_event__bot=self)
+            for debug_screenshot in debug_screenshots:
+                if debug_screenshot.file and debug_screenshot.file.name:
+                    debug_screenshot.file.delete()
+            debug_screenshots.delete()
 
             # Delete all utterances and recording files for each recording
             for recording in self.recordings.all():

--- a/bots/tests/test_bot_data_deletion.py
+++ b/bots/tests/test_bot_data_deletion.py
@@ -1,7 +1,9 @@
+import threading
 import uuid
 from unittest.mock import PropertyMock, patch
 
 from django.core.files.base import ContentFile
+from django.db import close_old_connections
 from django.test import Client, TransactionTestCase
 from django.test.utils import override_settings
 from rest_framework import status
@@ -211,7 +213,9 @@ class TestBotDataDeletion(TransactionTestCase):
         self.bot1.delete_data()
 
         deleted_file_owners = {(type(call.args[0].instance), call.args[0].instance.pk) for call in self.delete_mock.call_args_list}
+        debug_file_delete_call = next(call for call in self.delete_mock.call_args_list if isinstance(call.args[0].instance, BotDebugScreenshot))
         self.assertEqual(self.delete_mock.call_count, 2)
+        self.assertEqual(debug_file_delete_call.kwargs, {"save": False})
         self.assertEqual(
             deleted_file_owners,
             {
@@ -219,6 +223,202 @@ class TestBotDataDeletion(TransactionTestCase):
                 (BotDebugScreenshot, self.screenshot1.pk),
             },
         )
+
+    def test_delete_data_is_idempotent(self):
+        """Test that retrying delete_data succeeds without creating another event"""
+        self.bot1.delete_data()
+        self.bot1.delete_data()
+
+        self.bot1.refresh_from_db()
+        self.assertEqual(self.bot1.state, BotStates.DATA_DELETED)
+        self.assertEqual(self.bot1.bot_events.filter(event_type=BotEventTypes.DATA_DELETED).count(), 1)
+
+    def test_debug_artifact_cannot_be_created_after_data_deletion(self):
+        """Test that cleanup cannot create a new artifact after delete_data succeeds"""
+        self.bot1.delete_data()
+        data_deleted_event = self.bot1.bot_events.get(event_type=BotEventTypes.DATA_DELETED)
+
+        with self.assertRaises(ValueError):
+            BotDebugScreenshot.create_with_file(
+                bot_event=data_deleted_event,
+                filename_template="late_debug_recording_{object_id}.mp4",
+                content=ContentFile(b"late debug recording"),
+            )
+
+        self.assertEqual(BotDebugScreenshot.objects.filter(bot_event__bot=self.bot1).count(), 0)
+
+    def test_direct_late_file_save_is_removed_after_data_deletion(self):
+        """Test that a stale artifact instance cannot leave a late-uploaded file behind"""
+        late_artifact = BotDebugScreenshot.objects.create(bot_event=self.event1)
+        self.bot1.delete_data()
+        self.delete_mock.reset_mock()
+
+        with self.assertRaises(ValueError):
+            late_artifact.file.save("late_debug_recording.mp4", ContentFile(b"late debug recording"))
+
+        self.assertEqual(self.delete_mock.call_count, 1)
+        self.assertEqual(self.delete_mock.call_args.kwargs, {"save": False})
+        self.assertFalse(BotDebugScreenshot.objects.filter(pk=late_artifact.pk).exists())
+
+    def test_delete_data_waits_for_in_progress_debug_upload(self):
+        """Test that artifact upload and deletion serialize on the bot row"""
+        upload_started = threading.Event()
+        release_upload = threading.Event()
+        deletion_finished = threading.Event()
+        thread_errors = []
+
+        def blocking_file_save(instance, name, content, save=True):
+            if name.startswith("concurrent_debug_recording_"):
+                upload_started.set()
+                if not release_upload.wait(timeout=5):
+                    raise TimeoutError("timed out waiting to release the test upload")
+            mock_file_field_save(instance, name, content, save=save)
+
+        self.save_mock.side_effect = blocking_file_save
+
+        def create_artifact():
+            close_old_connections()
+            try:
+                event = BotEvent.objects.get(pk=self.event1.pk)
+                BotDebugScreenshot.create_with_file(
+                    bot_event=event,
+                    filename_template="concurrent_debug_recording_{object_id}.mp4",
+                    content=ContentFile(b"concurrent debug recording"),
+                )
+            except Exception as exc:
+                thread_errors.append(exc)
+            finally:
+                close_old_connections()
+
+        def delete_data():
+            close_old_connections()
+            try:
+                Bot.objects.get(pk=self.bot1.pk).delete_data()
+            except Exception as exc:
+                thread_errors.append(exc)
+            finally:
+                deletion_finished.set()
+                close_old_connections()
+
+        artifact_thread = threading.Thread(target=create_artifact)
+        artifact_thread.start()
+        self.assertTrue(upload_started.wait(timeout=5))
+
+        deletion_thread = threading.Thread(target=delete_data)
+        deletion_thread.start()
+        self.assertFalse(deletion_finished.wait(timeout=0.2))
+
+        release_upload.set()
+        artifact_thread.join(timeout=5)
+        deletion_thread.join(timeout=5)
+
+        self.assertFalse(artifact_thread.is_alive())
+        self.assertFalse(deletion_thread.is_alive())
+        self.assertEqual(thread_errors, [])
+        self.bot1.refresh_from_db()
+        self.assertEqual(self.bot1.state, BotStates.DATA_DELETED)
+        self.assertFalse(BotDebugScreenshot.objects.filter(bot_event__bot=self.bot1).exists())
+
+    def test_debug_upload_waits_for_deletion_and_is_rejected(self):
+        """Test that an upload waiting behind deletion observes DATA_DELETED"""
+        deletion_holds_lock = threading.Event()
+        release_deletion = threading.Event()
+        upload_finished = threading.Event()
+        upload_rejected = threading.Event()
+        thread_errors = []
+
+        def blocking_file_delete(instance, save=True):
+            if isinstance(instance.instance, BotDebugScreenshot) and not deletion_holds_lock.is_set():
+                deletion_holds_lock.set()
+                if not release_deletion.wait(timeout=5):
+                    raise TimeoutError("timed out waiting to release deletion")
+            mock_file_field_delete_sets_name_to_none(instance, save=save)
+
+        self.delete_mock.side_effect = blocking_file_delete
+
+        def delete_data():
+            close_old_connections()
+            try:
+                Bot.objects.get(pk=self.bot1.pk).delete_data()
+            except Exception as exc:
+                thread_errors.append(exc)
+            finally:
+                close_old_connections()
+
+        def create_artifact():
+            close_old_connections()
+            try:
+                event = BotEvent.objects.get(pk=self.event1.pk)
+                BotDebugScreenshot.create_with_file(
+                    bot_event=event,
+                    filename_template="too_late_debug_recording_{object_id}.mp4",
+                    content=ContentFile(b"too late debug recording"),
+                )
+            except ValueError:
+                upload_rejected.set()
+            except Exception as exc:
+                thread_errors.append(exc)
+            finally:
+                upload_finished.set()
+                close_old_connections()
+
+        deletion_thread = threading.Thread(target=delete_data)
+        deletion_thread.start()
+        self.assertTrue(deletion_holds_lock.wait(timeout=5))
+
+        artifact_thread = threading.Thread(target=create_artifact)
+        artifact_thread.start()
+        self.assertFalse(upload_finished.wait(timeout=0.2))
+
+        release_deletion.set()
+        deletion_thread.join(timeout=5)
+        artifact_thread.join(timeout=5)
+
+        self.assertFalse(deletion_thread.is_alive())
+        self.assertFalse(artifact_thread.is_alive())
+        self.assertEqual(thread_errors, [])
+        self.assertTrue(upload_rejected.is_set())
+        self.bot1.refresh_from_db()
+        self.assertEqual(self.bot1.state, BotStates.DATA_DELETED)
+        self.assertFalse(BotDebugScreenshot.objects.filter(bot_event__bot=self.bot1).exists())
+
+    def test_delete_data_can_retry_after_storage_failure(self):
+        """Test that a partial storage failure rolls back database changes and can be retried"""
+        failed_once = False
+
+        def fail_recording_delete_once(instance, save=True):
+            nonlocal failed_once
+            if isinstance(instance.instance, Recording) and not failed_once:
+                failed_once = True
+                raise OSError("storage unavailable")
+            mock_file_field_delete_sets_name_to_none(instance, save=save)
+
+        self.delete_mock.side_effect = fail_recording_delete_once
+        with self.assertRaises(OSError):
+            self.bot1.delete_data()
+
+        self.bot1.refresh_from_db()
+        self.screenshot1.refresh_from_db()
+        self.assertEqual(self.bot1.state, BotStates.ENDED)
+        self.assertTrue(self.screenshot1.file)
+        self.assertTrue(Participant.objects.filter(bot=self.bot1).exists())
+
+        self.delete_mock.side_effect = mock_file_field_delete_sets_name_to_none
+        self.bot1.delete_data()
+        self.bot1.refresh_from_db()
+        self.assertEqual(self.bot1.state, BotStates.DATA_DELETED)
+        self.assertFalse(BotDebugScreenshot.objects.filter(bot_event__bot=self.bot1).exists())
+
+    def test_delete_data_removes_debug_rows_without_files(self):
+        """Test that empty debug artifact rows are removed without a storage call"""
+        empty_artifact = BotDebugScreenshot.objects.create(bot_event=self.event1)
+        self.delete_mock.reset_mock()
+
+        self.bot1.delete_data()
+
+        deleted_file_owners = {(type(call.args[0].instance), call.args[0].instance.pk) for call in self.delete_mock.call_args_list}
+        self.assertNotIn((BotDebugScreenshot, empty_artifact.pk), deleted_file_owners)
+        self.assertFalse(BotDebugScreenshot.objects.filter(pk=empty_artifact.pk).exists())
 
     def test_delete_data_multiple_recordings(self):
         """Test that delete_data deletes data from multiple recordings"""

--- a/bots/tests/test_bot_data_deletion.py
+++ b/bots/tests/test_bot_data_deletion.py
@@ -204,6 +204,22 @@ class TestBotDataDeletion(TransactionTestCase):
         self.assertEqual(AudioChunk.objects.filter(recording__bot=self.bot1).count(), 1)
         self.assertEqual(Utterance.objects.filter(recording__bot=self.bot1).count(), 1)
 
+    def test_delete_data_deletes_recording_and_debug_files_from_storage(self):
+        """Test that delete_data deletes the bot's recording and debug files from storage"""
+        self.delete_mock.reset_mock()
+
+        self.bot1.delete_data()
+
+        deleted_file_owners = {(type(call.args[0].instance), call.args[0].instance.pk) for call in self.delete_mock.call_args_list}
+        self.assertEqual(self.delete_mock.call_count, 2)
+        self.assertEqual(
+            deleted_file_owners,
+            {
+                (Recording, self.recording1.pk),
+                (BotDebugScreenshot, self.screenshot1.pk),
+            },
+        )
+
     def test_delete_data_multiple_recordings(self):
         """Test that delete_data deletes data from multiple recordings"""
         # Create another recording for bot1


### PR DESCRIPTION
## Summary

- delete every debug screenshot, MHTML capture, screen recording, and bot-log object from configured storage before removing its database row
- serialize debug-artifact uploads with bot data deletion so a cleanup upload cannot recreate sensitive data after deletion succeeds
- make deletion retry-safe after partial storage failures and idempotent once the bot reaches `DATA_DELETED`
- route all six production debug-artifact write paths through the guarded creation helper
- add regression and real PostgreSQL concurrency coverage for both upload-before-delete and delete-before-upload orderings

## Root cause

`QuerySet.delete()` removed `BotDebugScreenshot` rows without invoking the `FileField` storage backend, which left debug artifacts orphaned in object storage. The initial fix also needed protection against cleanup writers racing with the deletion sweep and uploading a new object after deletion.

## Impact

`delete_data()` removes the selected bot's debug artifacts from object storage while preserving other bots' objects. Late artifact creation is rejected, a directly uploaded late object is cleaned up, and repeated deletion converges safely without creating duplicate `DATA_DELETED` events.

The bot row lock intentionally spans storage I/O to guarantee that deletion cannot report success while a debug upload for the same bot is still active. This trades longer per-bot lock duration for deterministic deletion semantics.

## Validation

- 18 targeted Django tests passed against local PostgreSQL and Redis, including 13 bot-data-deletion tests, four hard-deletion tests, and the bot-log attachment integration test
- real MinIO integration passed: target recording and debug objects deleted, control-bot objects preserved, late upload removed, post-delete creation blocked, empty artifact row removed, and repeated deletion succeeded
- `ruff check` passed for all three changed files
- `ruff format --check` passed for all three changed files
- `python -m py_compile` passed for all three changed files
- `git diff --check` passed
- Claude Code CLI 2.1.234 (Sonnet) final review: no blocking findings; only the documented lock-across-storage-I/O tradeoff

Closes #960
