### PR TITLE
feat: allow disabling chat message recording

### DIFF
--- a/bots/bot_controller/bot_controller.py
+++ b/bots/bot_controller/bot_controller.py
@@ -123,6 +123,11 @@ class BotController:
     def should_modify_dom_for_video_recording_for_web_bots(self):
         return self.pipeline_configuration.record_video or self.pipeline_configuration.rtmp_stream_video
 
+    def get_upsert_chat_message_callback(self):
+        if not self.bot_in_db.record_chat_messages():
+            return None
+        return self.on_new_chat_message
+
     # Constructs the callback we'll use to receive per-participant audio chunks
     # For most cases, we'll feed them to the per-participant audio input manager which will transcribe them and store the audio chunks for post-meeting transcription
     # If per participant audio is being streamed via websocket, we'll send them to the websocket client
@@ -194,7 +199,7 @@ class BotController:
             add_mixed_audio_chunk_callback=self.add_mixed_audio_chunk_callback if self.pipeline_configuration.websocket_stream_audio else None,
             add_per_participant_video_frame_callback=self.add_per_participant_video_frame_callback if self.pipeline_configuration.websocket_stream_per_participant_video else None,
             upsert_caption_callback=self.closed_caption_manager.upsert_caption if self.save_utterances_for_closed_captions() else None,
-            upsert_chat_message_callback=self.on_new_chat_message,
+            upsert_chat_message_callback=self.get_upsert_chat_message_callback(),
             add_participant_event_callback=self.on_new_participant_event,
             automatic_leave_configuration=self.automatic_leave_configuration,
             per_participant_realtime_video_configuration=self.per_participant_realtime_video_configuration,
@@ -266,7 +271,7 @@ class BotController:
             add_mixed_audio_chunk_callback=self.add_mixed_audio_chunk_callback if self.pipeline_configuration.websocket_stream_audio else None,
             add_per_participant_video_frame_callback=self.add_per_participant_video_frame_callback if self.pipeline_configuration.websocket_stream_per_participant_video else None,
             upsert_caption_callback=self.closed_caption_manager.upsert_caption if self.save_utterances_for_closed_captions() else None,
-            upsert_chat_message_callback=self.on_new_chat_message,
+            upsert_chat_message_callback=self.get_upsert_chat_message_callback(),
             add_participant_event_callback=self.on_new_participant_event,
             automatic_leave_configuration=self.automatic_leave_configuration,
             per_participant_realtime_video_configuration=self.per_participant_realtime_video_configuration,
@@ -343,7 +348,7 @@ class BotController:
             add_mixed_audio_chunk_callback=self.add_mixed_audio_chunk_callback if self.pipeline_configuration.websocket_stream_audio else None,
             add_per_participant_video_frame_callback=self.add_per_participant_video_frame_callback if self.pipeline_configuration.websocket_stream_per_participant_video else None,
             upsert_caption_callback=self.closed_caption_manager.upsert_caption if self.save_utterances_for_closed_captions() else None,
-            upsert_chat_message_callback=self.on_new_chat_message,
+            upsert_chat_message_callback=self.get_upsert_chat_message_callback(),
             add_participant_event_callback=self.on_new_participant_event,
             automatic_leave_configuration=self.automatic_leave_configuration,
             per_participant_realtime_video_configuration=self.per_participant_realtime_video_configuration,
@@ -382,7 +387,7 @@ class BotController:
             wants_any_video_frames_callback=self.gstreamer_pipeline.wants_any_video_frames if self.gstreamer_pipeline else lambda: False,
             add_mixed_audio_chunk_callback=self.add_mixed_audio_chunk_callback,
             add_per_participant_video_frame_callback=self.add_per_participant_video_frame_callback if self.pipeline_configuration.websocket_stream_per_participant_video else None,
-            upsert_chat_message_callback=self.on_new_chat_message,
+            upsert_chat_message_callback=self.get_upsert_chat_message_callback(),
             add_participant_event_callback=self.on_new_participant_event,
             automatic_leave_configuration=self.automatic_leave_configuration,
             per_participant_realtime_video_configuration=self.per_participant_realtime_video_configuration,
@@ -411,7 +416,7 @@ class BotController:
             add_video_frame_callback=self.gstreamer_pipeline.on_new_video_frame if self.gstreamer_pipeline else None,
             wants_any_video_frames_callback=self.gstreamer_pipeline.wants_any_video_frames if self.gstreamer_pipeline else lambda: False,
             add_mixed_audio_chunk_callback=self.add_mixed_audio_chunk_callback,
-            upsert_chat_message_callback=self.on_new_chat_message,
+            upsert_chat_message_callback=self.get_upsert_chat_message_callback(),
             add_participant_event_callback=self.on_new_participant_event,
             video_frame_size=self.bot_in_db.recording_dimensions(),
         )
@@ -1535,6 +1540,8 @@ class BotController:
         self.create_utterance_from_audio_chunk(audio_chunk, participant, recording)
 
     def on_new_chat_message(self, chat_message):
+        if not self.bot_in_db.record_chat_messages():
+            return
         GLib.idle_add(lambda: self.upsert_chat_message(chat_message))
 
     def on_message_that_webpage_streamer_connection_can_start(self):
@@ -1601,6 +1608,9 @@ class BotController:
         return
 
     def upsert_chat_message(self, chat_message):
+        if not self.bot_in_db.record_chat_messages():
+            return
+
         logger.info(f"Upserting chat message: {chat_message}")
 
         participant = self.adapter.get_participant(chat_message["participant_uuid"])

--- a/bots/google_meet_bot_adapter/google_meet_chromedriver_payload.js
+++ b/bots/google_meet_bot_adapter/google_meet_chromedriver_payload.js
@@ -907,6 +907,9 @@ class ChatMessageManager {
     }
 
     handleChatMessage(chatMessageRaw) {
+        if (!window.initialData.collectChatMessages)
+            return;
+
         try {
             const chatMessage = chatMessageRaw.chatMessage;
             console.log('handleChatMessage', chatMessage);
@@ -1713,6 +1716,11 @@ function createMessageDecoder(messageType) {
                 continue;
             }
 
+            if (!window.initialData.collectChatMessages && messageType.name === 'UserInfoListWrapperAndChatWrapper' && field.name === 'chatMessageWrapper') {
+                reader.skipType(tag & 7);
+                continue;
+            }
+
             let value;
             switch (field.type) {
                 case 'string':
@@ -1753,7 +1761,7 @@ const captionManager = new CaptionManager(ws);
 const videoTrackManager = new VideoTrackManager(ws);
 const styleManager = new StyleManager();
 const receiverManager = new ReceiverManager();
-const chatMessageManager = new ChatMessageManager(ws);
+const chatMessageManager = window.initialData.collectChatMessages ? new ChatMessageManager(ws) : null;
 const participantSpeechStartStopManager = new ParticipantSpeechStartStopManager();
 let rtpReceiverInterceptor = null;
 if (window.initialData.sendPerParticipantAudio || window.initialData.recordParticipantSpeechStartStopEvents) {
@@ -1813,10 +1821,12 @@ const handleCollectionEvent = (event) => {
     userManager.updateDeviceOutputs(deviceOutputInfoList);
   }
 
-  const chatMessageWrapper = collectionEvent.body.userInfoListWrapperAndChatWrapperWrapper?.userInfoListWrapperAndChatWrapper?.chatMessageWrapper;
-  if (chatMessageWrapper) {
-    for (const chatMessage of chatMessageWrapper) {
-        window.chatMessageManager?.handleChatMessage(chatMessage);
+  if (window.initialData.collectChatMessages) {
+    const chatMessageWrapper = collectionEvent.body.userInfoListWrapperAndChatWrapperWrapper?.userInfoListWrapperAndChatWrapper?.chatMessageWrapper;
+    if (chatMessageWrapper) {
+      for (const chatMessage of chatMessageWrapper) {
+          window.chatMessageManager?.handleChatMessage(chatMessage);
+      }
     }
   }
 

--- a/bots/models.py
+++ b/bots/models.py
@@ -1137,11 +1137,17 @@ class Bot(models.Model):
             recording_settings = {}
         return recording_settings.get("format", RecordingFormats.MP4)
 
+    def record_chat_messages(self):
+        recording_settings = self.settings.get("recording_settings", {})
+        if recording_settings is None:
+            recording_settings = {}
+        return recording_settings.get("record_chat_messages", True)
+
     def record_chat_messages_when_paused(self):
         recording_settings = self.settings.get("recording_settings", {})
         if recording_settings is None:
             recording_settings = {}
-        return recording_settings.get("record_chat_messages_when_paused", False)
+        return self.record_chat_messages() and recording_settings.get("record_chat_messages_when_paused", False)
 
     def reserve_additional_storage(self):
         recording_settings = self.settings.get("recording_settings", {})

--- a/bots/serializers.py
+++ b/bots/serializers.py
@@ -653,6 +653,7 @@ BOT_RECORDING_SETTINGS_DEFAULT_VALUES = {
     "format": RecordingFormats.MP4,
     "view": RecordingViews.SPEAKER_VIEW,
     "resolution": RecordingResolutions.HD_1080P,
+    "record_chat_messages": True,
     "record_chat_messages_when_paused": False,
     "record_async_transcription_audio_chunks": False,
     "record_participant_speech_start_stop_events": False,
@@ -674,9 +675,14 @@ BOT_RECORDING_SETTINGS_SCHEMA = {
             "description": "The resolution to use for the recording. The supported resolutions are '1080p' and '720p'. Defaults to '1080p'.",
             "enum": RecordingResolutions.values,
         },
+        "record_chat_messages": {
+            "type": "boolean",
+            "description": "Whether to record chat messages from meeting participants. Defaults to true.",
+            "default": True,
+        },
         "record_chat_messages_when_paused": {
             "type": "boolean",
-            "description": "Whether to record chat messages even when the recording is paused. Defaults to false.",
+            "description": "Whether to record chat messages even when the recording is paused. Ignored when record_chat_messages is false. Defaults to false.",
             "default": False,
         },
         "record_async_transcription_audio_chunks": {

--- a/bots/teams_bot_adapter/teams_chromedriver_payload.js
+++ b/bots/teams_bot_adapter/teams_chromedriver_payload.js
@@ -1254,6 +1254,9 @@ class ChatMessageManager {
     }
 
     handleChatMessage(chatMessage) {
+        if (!window.initialData.collectChatMessages)
+            return;
+
         try {
             if (!chatMessage.clientMessageId)
                 return;
@@ -2200,7 +2203,7 @@ window.ws = ws;
 const userManager = new UserManager(ws);
 window.userManager = userManager;
 
-const chatMessageManager = new ChatMessageManager(ws);
+const chatMessageManager = window.initialData.collectChatMessages ? new ChatMessageManager(ws) : null;
 window.chatMessageManager = chatMessageManager;
 
 //const videoTrackManager = new VideoTrackManager(ws);
@@ -3470,7 +3473,7 @@ window.botOutputManager = botOutputManager;
             const bound = _bind.apply(this, [thisArg, ...args]);
             return function (...callArgs) {
                 const eventData = callArgs[0];
-                if (eventData?.data?.chatServiceBatchEvent)
+                if (window.initialData.collectChatMessages && eventData?.data?.chatServiceBatchEvent)
                 {
                     const batchEvents = eventData.data.chatServiceBatchEvent;
                     if (Array.isArray(batchEvents))

--- a/bots/tests/test_chat_recording_settings.py
+++ b/bots/tests/test_chat_recording_settings.py
@@ -1,0 +1,105 @@
+import json
+from unittest.mock import MagicMock, patch
+
+from django.test import SimpleTestCase, TestCase
+
+from accounts.models import Organization
+from bots.bot_controller import BotController
+from bots.bots_api_utils import BotCreationSource, create_bot
+from bots.models import BotChatMessageRequest, BotChatMessageRequestStates, BotChatMessageToOptions, ChatMessage, Project
+from bots.web_bot_adapter.web_bot_adapter import WebBotAdapter
+from bots.zoom_bot_adapter.zoom_bot_adapter import ZoomBotAdapter
+
+
+class TestChatRecordingSettings(TestCase):
+    def setUp(self):
+        organization = Organization.objects.create(name="Test Organization")
+        self.project = Project.objects.create(name="Test Project", organization=organization)
+
+    def create_google_meet_bot(self, recording_settings=None):
+        data = {
+            "meeting_url": "https://meet.google.com/abc-defg-hij",
+            "bot_name": "Test Bot",
+        }
+        if recording_settings is not None:
+            data["recording_settings"] = recording_settings
+
+        bot, error = create_bot(data=data, source=BotCreationSource.API, project=self.project)
+        self.assertIsNone(error)
+        return bot
+
+    def test_chat_recording_defaults_to_enabled(self):
+        bot = self.create_google_meet_bot()
+
+        self.assertTrue(bot.record_chat_messages())
+        self.assertTrue(bot.settings["recording_settings"]["record_chat_messages"])
+        self.assertIsNotNone(BotController(bot.id).get_upsert_chat_message_callback())
+
+    def test_disabling_chat_recording_prevents_incoming_messages_from_being_scheduled_or_saved(self):
+        bot = self.create_google_meet_bot(
+            {
+                "record_chat_messages": False,
+                "record_chat_messages_when_paused": True,
+            }
+        )
+        controller = BotController(bot.id)
+        controller.adapter = MagicMock()
+        chat_message = {"text": "sensitive meeting chat"}
+
+        self.assertFalse(bot.record_chat_messages())
+        self.assertFalse(bot.record_chat_messages_when_paused())
+        self.assertIsNone(controller.get_upsert_chat_message_callback())
+
+        with patch("bots.bot_controller.bot_controller.GLib.idle_add") as idle_add:
+            controller.on_new_chat_message(chat_message)
+        idle_add.assert_not_called()
+
+        controller.upsert_chat_message(chat_message)
+        controller.adapter.get_participant.assert_not_called()
+        self.assertFalse(ChatMessage.objects.filter(bot=bot).exists())
+
+    def test_disabling_chat_recording_does_not_disable_outgoing_messages(self):
+        bot = self.create_google_meet_bot({"record_chat_messages": False})
+        request = BotChatMessageRequest.objects.create(
+            bot=bot,
+            message="A message from the bot",
+            to=BotChatMessageToOptions.EVERYONE,
+        )
+        controller = BotController(bot.id)
+        controller.adapter = MagicMock()
+        controller.adapter.is_ready_to_send_chat_messages.return_value = True
+
+        controller.take_action_based_on_chat_message_requests_in_db()
+
+        controller.adapter.send_chat_message.assert_called_once_with(
+            text="A message from the bot",
+            to_user_uuid=None,
+        )
+        request.refresh_from_db()
+        self.assertEqual(request.state, BotChatMessageRequestStates.SENT)
+
+
+class TestDisabledChatRecordingAdapters(SimpleTestCase):
+    def test_web_adapter_drops_chat_messages_before_logging_or_dispatch(self):
+        adapter = object.__new__(WebBotAdapter)
+        adapter.upsert_chat_message_callback = None
+        message = (1).to_bytes(4, byteorder="little") + json.dumps(
+            {
+                "type": "ChatMessage",
+                "text": "sensitive meeting chat",
+            }
+        ).encode("utf-8")
+
+        with patch("bots.web_bot_adapter.web_bot_adapter.logger.info") as logger_info:
+            adapter.handle_websocket([message])
+
+        logger_info.assert_not_called()
+
+    def test_zoom_adapter_does_not_read_chat_content_without_callback(self):
+        adapter = object.__new__(ZoomBotAdapter)
+        adapter.upsert_chat_message_callback = None
+        chat_message = MagicMock()
+
+        adapter.on_chat_msg_notification_callback(chat_message, None)
+
+        chat_message.GetContent.assert_not_called()

--- a/bots/web_bot_adapter/web_bot_adapter.py
+++ b/bots/web_bot_adapter/web_bot_adapter.py
@@ -348,6 +348,9 @@ class WebBotAdapter(BotAdapter):
         self.add_participant_event_callback({"participant_uuid": json_data["participantId"], "event_type": ParticipantEventTypes.SPEECH_START if json_data["isSpeechStart"] else ParticipantEventTypes.SPEECH_STOP, "event_data": {}, "timestamp_ms": int(json_data["timestamp"])})
 
     def handle_chat_message(self, json_data):
+        if self.upsert_chat_message_callback is None:
+            return
+
         if self.recording_paused and not self.record_chat_messages_when_paused:
             return
 
@@ -378,6 +381,9 @@ class WebBotAdapter(BotAdapter):
                         logger.warning("Received non-dict JSON message: %s (type: %s)", json_data, type(json_data).__name__)
 
                     if json_data_is_dict:
+                        if json_data.get("type") == "ChatMessage" and self.upsert_chat_message_callback is None:
+                            continue
+
                         if json_data.get("type") == "CaptionUpdate":
                             logger.info("Received JSON message: %s", self.mask_transcript_if_required(json_data))
                         else:
@@ -653,7 +659,7 @@ class WebBotAdapter(BotAdapter):
         self.driver = webdriver.Chrome(options=options, service=Service(executable_path="/usr/local/bin/chromedriver"))
         logger.info(f"web driver server initialized at port {self.driver.service.port}")
 
-        initial_data_code = f"window.initialData = {{websocketPort: {self.websocket_port}, videoFrameWidth: {self.video_frame_size[0]}, videoFrameHeight: {self.video_frame_size[1]}, botName: {json.dumps(self.display_name)}, addClickRipple: {'true' if self.should_create_debug_recording else 'false'}, recordingView: '{self.recording_view}', sendMixedAudio: {'true' if self.add_mixed_audio_chunk_callback else 'false'}, sendPerParticipantAudio: {'true' if self.add_audio_chunk_callback else 'false'}, perParticipantRealtimeVideoConfiguration: {json.dumps(self.per_participant_realtime_video_configuration.to_dict())}, sendPerParticipantVideo: {'true' if self.add_per_participant_video_frame_callback else 'false'}, collectCaptions: {'true' if self.upsert_caption_callback else 'false'}, recordParticipantSpeechStartStopEvents: {'true' if self.record_participant_speech_start_stop_events else 'false'}}}"
+        initial_data_code = f"window.initialData = {{websocketPort: {self.websocket_port}, videoFrameWidth: {self.video_frame_size[0]}, videoFrameHeight: {self.video_frame_size[1]}, botName: {json.dumps(self.display_name)}, addClickRipple: {'true' if self.should_create_debug_recording else 'false'}, recordingView: '{self.recording_view}', sendMixedAudio: {'true' if self.add_mixed_audio_chunk_callback else 'false'}, sendPerParticipantAudio: {'true' if self.add_audio_chunk_callback else 'false'}, perParticipantRealtimeVideoConfiguration: {json.dumps(self.per_participant_realtime_video_configuration.to_dict())}, sendPerParticipantVideo: {'true' if self.add_per_participant_video_frame_callback else 'false'}, collectCaptions: {'true' if self.upsert_caption_callback else 'false'}, collectChatMessages: {'true' if self.upsert_chat_message_callback else 'false'}, recordParticipantSpeechStartStopEvents: {'true' if self.record_participant_speech_start_stop_events else 'false'}}}"
 
         # Get directory of current file
         current_dir = os.path.dirname(os.path.abspath(__file__))

--- a/bots/zoom_bot_adapter/zoom_bot_adapter.py
+++ b/bots/zoom_bot_adapter/zoom_bot_adapter.py
@@ -522,6 +522,9 @@ class ZoomBotAdapter(BotAdapter):
         builder.Clear()
 
     def on_chat_msg_notification_callback(self, chat_msg_info, content):
+        if self.upsert_chat_message_callback is None:
+            return
+
         if self.recording_is_paused and not self.record_chat_messages_when_paused:
             logger.info("on_chat_msg_notification_callback called but recording is paused")
             return
@@ -628,8 +631,10 @@ class ZoomBotAdapter(BotAdapter):
 
         # Chats controller
         self.chat_ctrl = self.meeting_service.GetMeetingChatController()
-        self.chat_ctrl_event = zoom.MeetingChatEventCallbacks(onChatMsgNotificationCallback=self.on_chat_msg_notification_callback)
-        self.chat_ctrl.SetEvent(self.chat_ctrl_event)
+        self.chat_ctrl_event = None
+        if self.upsert_chat_message_callback is not None:
+            self.chat_ctrl_event = zoom.MeetingChatEventCallbacks(onChatMsgNotificationCallback=self.on_chat_msg_notification_callback)
+            self.chat_ctrl.SetEvent(self.chat_ctrl_event)
         self.ready_to_send_chat_messages = True
         self.send_message_callback({"message": self.Messages.READY_TO_SEND_CHAT_MESSAGE})
 

--- a/docs/basics.md
+++ b/docs/basics.md
@@ -51,6 +51,7 @@ Transcription Settings
 Recording Settings
    - Recording type (Audio and Video / Audio Only)
    - Recording view (Speaker View / Gallery View)
+   - Meeting chat message recording
 
 Automatic leave settings
    - How long should the bot wait to be let into the meeting before giving up?
@@ -61,6 +62,20 @@ Automatic leave settings
 Webhooks
    - Bot state changes
    - Transcript updates
+
+### Disabling chat message recording
+
+By default, bots record chat messages sent by meeting participants. To disable incoming chat message recording, set `record_chat_messages` to `false`:
+
+```json
+{
+  "recording_settings": {
+    "record_chat_messages": false
+  }
+}
+```
+
+This setting does not prevent the bot from sending chat messages.
 
 ## Platform Support
 Currently supported platforms:

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -2664,10 +2664,16 @@ components:
               enum:
               - 1080p
               - 720p
+            record_chat_messages:
+              type: boolean
+              description: Whether to record chat messages from meeting participants.
+                Defaults to true.
+              default: true
             record_chat_messages_when_paused:
               type: boolean
               description: Whether to record chat messages even when the recording
-                is paused. Defaults to false.
+                is paused. Ignored when record_chat_messages is false. Defaults to
+                false.
               default: false
             reserve_additional_storage:
               type: boolean
@@ -2681,6 +2687,7 @@ components:
             format: mp4
             view: speaker_view
             resolution: 1080p
+            record_chat_messages: true
             record_chat_messages_when_paused: false
             reserve_additional_storage: false
           description: The settings for the bot's recording.
@@ -3184,10 +3191,16 @@ components:
               enum:
               - 1080p
               - 720p
+            record_chat_messages:
+              type: boolean
+              description: Whether to record chat messages from meeting participants.
+                Defaults to true.
+              default: true
             record_chat_messages_when_paused:
               type: boolean
               description: Whether to record chat messages even when the recording
-                is paused. Defaults to false.
+                is paused. Ignored when record_chat_messages is false. Defaults to
+                false.
               default: false
             record_async_transcription_audio_chunks:
               type: boolean


### PR DESCRIPTION
## Summary

Adds a `recording_settings.record_chat_messages` option for disabling the recording of incoming meeting chat messages.

The option defaults to `true` to preserve existing behavior.

When set to `false`:

- Google Meet does not decode or forward incoming chat messages
- Microsoft Teams does not process or forward incoming chat events
- Zoom native bots do not register the incoming chat callback
- Incoming chat messages are not logged, stored, or sent through webhooks
- Bots can still send chat messages

## Usage

```json
{
  "recording_settings": {
    "record_chat_messages": false
  }
}
```

`record_chat_messages: false` takes precedence over `record_chat_messages_when_paused`.

## Testing

- Added tests for the default-enabled behavior
- Added tests confirming incoming messages are not scheduled or stored when disabled
- Added a regression test confirming outgoing chat messages still work
- Added adapter-level checks for web bots and Zoom
- Ran the existing bot creation and recording settings tests

No database migration is required because the option is stored in the existing recording settings JSON.
