### PR TITLE
fix: prevent Zoom SDK shutdown segfaults

### DIFF
--- a/bots/bot_controller/bot_controller.py
+++ b/bots/bot_controller/bot_controller.py
@@ -962,7 +962,7 @@ class BotController:
         def repeatedly_try_to_reconnect_to_redis():
             reconnect_delay_seconds = 1
             num_attempts = 0
-            while True:
+            while not redis_listener_stop.is_set():
                 try:
                     self.connect_to_redis()
                     break
@@ -974,13 +974,15 @@ class BotController:
                         raise Exception("Failed to reconnect to Redis after 30 attempts")
 
         def redis_listener():
-            while True:
+            while not redis_listener_stop.is_set():
                 try:
                     message = self.pubsub.get_message(timeout=1.0)
                     if message:
                         # Schedule Redis message handling in the main GLib loop
                         GLib.idle_add(self.handle_redis_message, message)
                 except Exception as e:
+                    if redis_listener_stop.is_set():
+                        break
                     # If this is a certain type of exception, we can attempt to reconnect
                     if isinstance(e, redis.exceptions.ConnectionError) and "Connection closed by server." in str(e):
                         logger.info("Redis connection closed by server. Attempting to reconnect...")
@@ -991,6 +993,7 @@ class BotController:
                         logger.warning(f"Error in Redis listener: {type(e)} {e}")
                         break
 
+        redis_listener_stop = threading.Event()
         redis_thread = threading.Thread(target=redis_listener, daemon=True)
         redis_thread.start()
 
@@ -1009,9 +1012,13 @@ class BotController:
             logger.warning(f"Error in bot {self.bot_in_db.id}: {str(e)}")
             self.cleanup()
         finally:
-            # Clean up Redis subscription
+            redis_listener_stop.set()
+            redis_thread.join(timeout=2)
             self.pubsub.unsubscribe(self.pubsub_channel)
             self.pubsub.close()
+            self.redis_client.close()
+            if redis_thread.is_alive():
+                redis_thread.join(timeout=2)
 
     def take_action_based_on_bot_in_db(self):
         if self.bot_in_db.state == BotStates.JOINING:

--- a/bots/management/commands/run_bot.py
+++ b/bots/management/commands/run_bot.py
@@ -1,4 +1,6 @@
 import logging
+import os
+import sys
 
 from django.core.management.base import BaseCommand
 
@@ -21,3 +23,9 @@ class Command(BaseCommand):
         result = run_bot.run(options["botid"])
 
         logger.info(f"Run bot task completed with result: {result}")
+        if "zoom_meeting_sdk" in sys.modules:
+            logging.shutdown()
+            sys.stdout.flush()
+            sys.stderr.flush()
+            # Zoom raw-data helper wrappers can segfault while Python finalizes after CleanUPSDK().
+            os._exit(0)

--- a/bots/tests/test_zoom_bot.py
+++ b/bots/tests/test_zoom_bot.py
@@ -1,5 +1,8 @@
 import base64
 import json
+import subprocess
+import sys
+import textwrap
 import threading
 import time
 from unittest.mock import ANY, MagicMock, call, patch
@@ -356,6 +359,73 @@ def create_mock_deepgram():
 
 
 @tag("zoom_tests")
+class TestZoomSDKShutdown(SimpleTestCase):
+    def test_run_bot_process_finalizes_normally_without_zoom_sdk(self):
+        script = """
+            import django
+
+            django.setup()
+
+            from bots.management.commands.run_bot import Command
+            from bots.tasks import run_bot
+
+            run_bot.run = lambda _bot_id: None
+            Command().handle(botid=1)
+            print("normal finalization completed")
+        """
+        completed = subprocess.run(
+            [sys.executable, "-c", textwrap.dedent(script)],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+
+        self.assertEqual(completed.returncode, 0)
+        self.assertIn("normal finalization completed", completed.stdout)
+
+    def test_run_bot_process_exits_before_zoom_raw_helper_finalization(self):
+        script = """
+            import django
+            import zoom_meeting_sdk as zoom
+
+            django.setup()
+
+            from bots.management.commands.run_bot import Command
+            from bots.tasks import run_bot
+
+            raw_helper = None
+
+            def run_with_raw_helper(_bot_id):
+                global raw_helper
+                params = zoom.InitParam()
+                params.strWebDomain = "https://zoom.us"
+                params.strSupportUrl = "https://zoom.us"
+                params.enableGenerateDump = False
+                params.emLanguageID = zoom.SDK_LANGUAGE_ID.LANGUAGE_English
+                params.enableLogByDefault = False
+                assert zoom.InitSDK(params) == zoom.SDKERR_SUCCESS
+                raw_helper = zoom.GetAudioRawdataHelper()
+                assert raw_helper is not None
+                zoom.CleanUPSDK()
+
+            run_bot.run = run_with_raw_helper
+            Command().handle(botid=1)
+        """
+        completed = subprocess.run(
+            [sys.executable, "-c", textwrap.dedent(script)],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+
+        self.assertEqual(
+            completed.returncode,
+            0,
+            f"stdout:\n{completed.stdout}\nstderr:\n{completed.stderr}",
+        )
+
+
+@tag("zoom_tests")
 class TestZoomParticipantTracking(SimpleTestCase):
     def test_missing_participant_does_not_start_only_participant_timer(self):
         adapter = ZoomBotAdapter.__new__(ZoomBotAdapter)
@@ -605,6 +675,7 @@ class TestZoomBot(TransactionTestCase):
         mock_zoom_sdk_adapter.CreateMeetingService.assert_called_once()
         mock_zoom_sdk_adapter.CreateAuthService.assert_called_once()
         controller.adapter.meeting_service.Join.assert_called_once()
+        mock_zoom_sdk_video.destroyRenderer.assert_called_once()
 
         # Cleanup
         controller.cleanup()
@@ -1088,6 +1159,7 @@ class TestZoomBot(TransactionTestCase):
         mock_zoom_sdk_adapter.CreateMeetingService.assert_called_once()
         mock_zoom_sdk_adapter.CreateAuthService.assert_called_once()
         controller.adapter.meeting_service.Join.assert_called_once()
+        mock_zoom_sdk_adapter.CleanUPSDK.assert_called_once()
 
         # Verify audio request was processed
         audio_request.refresh_from_db()

--- a/bots/zoom_bot_adapter/realtime_per_participant_video_frame_generator.py
+++ b/bots/zoom_bot_adapter/realtime_per_participant_video_frame_generator.py
@@ -405,9 +405,13 @@ class _PerParticipantVideoFrameSubscription:
         logger.info("Cleaning up subscription for participant %s (share_source_id %s)", self.participant_id, self.share_source_id)
         try:
             self._renderer.unSubscribe()
+            zoom.destroyRenderer(self._renderer)
         except Exception:
             logger.exception(
                 "Error while unsubscribing renderer for participant %s",
                 self.participant_id,
             )
         self.destroyed = True
+        self._renderer = None
+        self._delegate = None
+        self.owner = None

--- a/bots/zoom_bot_adapter/video_input_manager.py
+++ b/bots/zoom_bot_adapter/video_input_manager.py
@@ -176,7 +176,12 @@ class VideoInputStream:
         if self.renderer:
             logger.info(f"starting renderer unsubscription for user {self.user_id} and share source id {self.share_source_id}")
             self.renderer.unSubscribe()
+            zoom.destroyRenderer(self.renderer)
             logger.info(f"finished renderer unsubscription for user {self.user_id} and share source id {self.share_source_id}")
+
+        self.renderer_destroyed = True
+        self.renderer = None
+        self.renderer_delegate = None
 
     def on_renderer_destroyed_callback(self):
         self.renderer_destroyed = True
@@ -250,6 +255,7 @@ class VideoInputManager:
     def cleanup(self):
         for input_stream in self.input_streams:
             input_stream.cleanup()
+        self.input_streams.clear()
 
     def set_mode(self, *, mode, active_speaker_id, active_sharer_id, active_sharer_source_id):
         if mode != VideoInputManager.Mode.ACTIVE_SPEAKER and mode != VideoInputManager.Mode.ACTIVE_SHARER and mode != VideoInputManager.Mode.INACTIVE:

--- a/bots/zoom_bot_adapter/zoom_bot_adapter.py
+++ b/bots/zoom_bot_adapter/zoom_bot_adapter.py
@@ -415,6 +415,10 @@ class ZoomBotAdapter(BotAdapter):
         self.set_video_input_manager_based_on_state()
 
     def cleanup(self):
+        if self.cleaned_up:
+            return
+        self.cleaned_up = True
+
         if self.audio_source:
             performance_data = self.audio_source.getPerformanceData()
             logger.info(f"totalProcessingTimeMicroseconds = {performance_data.totalProcessingTimeMicroseconds}")
@@ -432,6 +436,23 @@ class ZoomBotAdapter(BotAdapter):
                         bin_start = bin_idx * bin_size
                         bin_end = (bin_idx + 1) * bin_size
                         logger.info(f"{bin_start:6.0f} - {bin_end:6.0f} us: {count:5d} calls")
+        if self.send_image_timeout_id is not None:
+            GLib.source_remove(self.send_image_timeout_id)
+            self.send_image_timeout_id = None
+        if self.stuck_in_connecting_state_timeout_id is not None:
+            GLib.source_remove(self.stuck_in_connecting_state_timeout_id)
+            self.stuck_in_connecting_state_timeout_id = None
+
+        if self.realtime_per_participant_video_frame_generator:
+            self.realtime_per_participant_video_frame_generator.reset()
+        if self.video_input_manager:
+            self.video_input_manager.cleanup()
+        if self.mp4_demuxer:
+            self.mp4_demuxer.stop()
+
+        if self.audio_helper:
+            audio_helper_unsubscribe_result = self.audio_helper.unSubscribe()
+            logger.info(f"audio_helper.unSubscribe() returned {audio_helper_unsubscribe_result}")
 
         if self.meeting_service:
             zoom.DestroyMeetingService(self.meeting_service)
@@ -443,17 +464,9 @@ class ZoomBotAdapter(BotAdapter):
             zoom.DestroyAuthService(self.auth_service)
             logger.info("Destroyed Auth service")
 
-        if self.audio_helper:
-            audio_helper_unsubscribe_result = self.audio_helper.unSubscribe()
-            logger.info(f"audio_helper.unSubscribe() returned {audio_helper_unsubscribe_result}")
-
-        if self.video_input_manager:
-            self.video_input_manager.cleanup()
-
         logger.info("CleanUPSDK() called")
         zoom.CleanUPSDK()
         logger.info("CleanUPSDK() finished")
-        self.cleaned_up = True
 
     def init(self):
         init_param = zoom.InitParam()
@@ -1051,6 +1064,7 @@ class ZoomBotAdapter(BotAdapter):
         GLib.timeout_add_seconds(wait_time, self.leave_meeting_if_not_started_yet)
 
     def give_up_if_still_in_connecting_state(self):
+        self.stuck_in_connecting_state_timeout_id = None
         if self.meeting_status != zoom.MEETING_STATUS_CONNECTING:
             return
 


### PR DESCRIPTION
## Summary

- stop the Redis listener, GLib timers, and media subscriptions before tearing down Zoom SDK services
- explicitly unsubscribe and destroy Zoom renderers before calling `CleanUPSDK()`
- avoid unsafe Python/nanobind finalization after a native Zoom bot process completes normally
- preserve normal interpreter finalization for processes that did not load the Zoom Meeting SDK

## Problem

A native Zoom bot process can complete its work successfully and then fail during Python interpreter shutdown. Zoom SDK service, callback, raw-data helper, or renderer wrappers may remain alive after `CleanUPSDK()`, causing nanobind finalization to segfault.

This change releases SDK-owned resources in dependency order. The `run_bot` command also flushes logging and standard streams before exiting the dedicated bot process without running the unsafe finalization path. This only happens after `run_bot.run()` returns normally and only when `zoom_meeting_sdk` was loaded; exceptions still propagate normally.

There are no API or user-facing behavior changes.

## Testing

- `python manage.py test bots.tests.test_zoom_bot.TestZoomSDKShutdown --verbosity 2`
- `python manage.py test bots.tests.test_zoom_bot.TestZoomBot.test_bot_can_wait_for_host_then_join_meeting bots.tests.test_zoom_bot.TestZoomBot.test_bot_can_join_meeting_and_record_audio_and_video --keepdb`
- `ruff check` on all changed Python files
- `ruff format --check` on all changed Python files

The shutdown regression test starts the real `zoom-meeting-sdk` in a child process, obtains a raw-data helper, calls `CleanUPSDK()`, and verifies that the bot command exits successfully. A companion test verifies that non-Zoom bot commands still use normal interpreter finalization.
