### PR TITLE
fix: serialize scheduled bot launch transitions

### DIFF
--- a/bots/management/commands/run_scheduler.py
+++ b/bots/management/commands/run_scheduler.py
@@ -246,14 +246,16 @@ class Command(BaseCommand):
 
     # -----------------------------------------------------------
     def _run_scheduled_bots(self):
+        """
+        Enqueue launches for scheduled bots within the join_at thresholds.
+
+        SELECT … FOR UPDATE SKIP LOCKED prevents overlapping transactions from
+        enqueueing the same bot. After commit the bot remains SCHEDULED until a
+        worker stages it, so another daemon can enqueue it again. Duplicate
+        tasks are handled by launch_scheduled_bot's locked state transition.
+        """
         if os.getenv("SCHEDULED_BOT_JITTER_START_SECONDS") and os.getenv("SCHEDULED_BOT_JITTER_END_SECONDS"):
             return self._run_scheduled_bots_with_jitter()
-
-        """
-        Promote objects whose join_at ≤ join_at_threshold.
-        Uses SELECT … FOR UPDATE SKIP LOCKED so multiple daemons
-        can run safely (e.g. during rolling deploys).
-        """
 
         # Give the bots 5 minutes to spin up, before they join the meeting.
         join_at_upper_threshold = timezone.now() + timezone.timedelta(minutes=5)

--- a/bots/tasks/launch_scheduled_bot_task.py
+++ b/bots/tasks/launch_scheduled_bot_task.py
@@ -1,6 +1,7 @@
 import logging
 
 from celery import shared_task
+from django.db import transaction
 
 from bots.launch_bot_utils import launch_bot
 from bots.models import Bot, BotEventManager, BotEventSubTypes, BotEventTypes, BotStates
@@ -12,18 +13,21 @@ logger = logging.getLogger(__name__)
 def launch_scheduled_bot(self, bot_id: int, bot_join_at: str):
     logger.info(f"Launching scheduled bot {bot_id} with join_at {bot_join_at}")
 
-    # Transition the bot to STAGED
-    bot = Bot.objects.get(id=bot_id)
+    # Serialize the state check and transition across duplicate task deliveries.
+    with transaction.atomic():
+        bot = Bot.objects.select_for_update().get(id=bot_id)
 
-    if bot.state != BotStates.SCHEDULED:
-        logger.info(f"Bot {bot_id} ({bot.object_id}) is not in state SCHEDULED, skipping")
-        return
+        if bot.state != BotStates.SCHEDULED:
+            logger.info(f"Bot {bot_id} ({bot.object_id}) is not in state SCHEDULED, skipping")
+            return
 
-    if bot.project.organization.out_of_credits():
-        logger.error(f"Bot {bot_id} ({bot.object_id}) was not launched because the organization ({bot.project.organization.id}) has insufficient credits.")
-        BotEventManager.create_event(bot=bot, event_type=BotEventTypes.FATAL_ERROR, event_sub_type=BotEventSubTypes.FATAL_ERROR_OUT_OF_CREDITS)
-        return
+        if bot.project.organization.out_of_credits():
+            logger.error(f"Bot {bot_id} ({bot.object_id}) was not launched because the organization ({bot.project.organization.id}) has insufficient credits.")
+            BotEventManager.create_event(bot=bot, event_type=BotEventTypes.FATAL_ERROR, event_sub_type=BotEventSubTypes.FATAL_ERROR_OUT_OF_CREDITS)
+            return
 
-    logger.info(f"Transitioning bot {bot_id} ({bot.object_id}) to STAGED")
-    BotEventManager.create_event(bot=bot, event_type=BotEventTypes.STAGED, event_metadata={"join_at": bot_join_at})
+        logger.info(f"Transitioning bot {bot_id} ({bot.object_id}) to STAGED")
+        BotEventManager.create_event(bot=bot, event_type=BotEventTypes.STAGED, event_metadata={"join_at": bot_join_at})
+
+    # Release the row lock before launching, which may call the Kubernetes API.
     launch_bot(bot)

--- a/bots/tasks/launch_scheduled_bot_task.py
+++ b/bots/tasks/launch_scheduled_bot_task.py
@@ -15,7 +15,7 @@ def launch_scheduled_bot(self, bot_id: int, bot_join_at: str):
 
     # Serialize the state check and transition across duplicate task deliveries.
     with transaction.atomic():
-        bot = Bot.objects.select_for_update().get(id=bot_id)
+        bot = Bot.objects.select_for_update(no_key=True).get(id=bot_id)
 
         if bot.state != BotStates.SCHEDULED:
             logger.info(f"Bot {bot_id} ({bot.object_id}) is not in state SCHEDULED, skipping")

--- a/bots/tests/test_launch_scheduled_bot_task.py
+++ b/bots/tests/test_launch_scheduled_bot_task.py
@@ -1,11 +1,16 @@
+import time
+from concurrent.futures import ThreadPoolExecutor
+from queue import Queue
+from threading import Event
 from unittest.mock import patch
 
 from django.core.exceptions import ValidationError
-from django.test import TestCase
+from django.db import connection, connections
+from django.test import TestCase, TransactionTestCase, skipUnlessDBFeature
 from django.utils import timezone as django_timezone
 
 from accounts.models import Organization
-from bots.models import Bot, BotEventSubTypes, BotEventTypes, BotStates, Project
+from bots.models import Bot, BotEventManager, BotEventSubTypes, BotEventTypes, BotStates, Project
 from bots.tasks.launch_scheduled_bot_task import launch_scheduled_bot
 
 
@@ -103,3 +108,66 @@ class LaunchScheduledBotTaskTestCase(TestCase):
 
             # Verify launch_bot was not called due to the error
             mock_launch_bot.assert_not_called()
+
+
+class ConcurrentLaunchScheduledBotTaskTestCase(TransactionTestCase):
+    @skipUnlessDBFeature("has_select_for_no_key_update")
+    def test_concurrent_deliveries_wait_for_staging(self):
+        organization = Organization.objects.create(name="Test Organization", centicredits=10000)
+        project = Project.objects.create(name="Test Project", organization=organization)
+        join_at = django_timezone.now().replace(microsecond=0)
+        bot = Bot.objects.create(project=project, name="Test Bot", meeting_url="https://example.zoom.us/j/123456789", state=BotStates.SCHEDULED, join_at=join_at)
+        staging_started = Event()
+        release_staging = Event()
+        worker_pids = Queue()
+        create_event = BotEventManager.create_event
+
+        def pause_before_staging(*args, **kwargs):
+            if not staging_started.is_set():
+                staging_started.set()
+                if not release_staging.wait(timeout=10):
+                    raise AssertionError("Timed out waiting to stage the bot")
+            return create_event(*args, **kwargs)
+
+        def run_task():
+            try:
+                with connection.cursor() as cursor:
+                    cursor.execute("SET statement_timeout = '10s'")
+                    cursor.execute("SELECT pg_backend_pid()")
+                    worker_pids.put(cursor.fetchone()[0])
+                launch_scheduled_bot(bot.id, join_at.isoformat())
+            finally:
+                connections.close_all()
+
+        def check_launch_committed(launched_bot):
+            self.assertFalse(connection.in_atomic_block)
+
+        with patch("bots.tasks.launch_scheduled_bot_task.launch_bot", side_effect=check_launch_committed) as mock_launch_bot, patch.object(BotEventManager, "create_event", side_effect=pause_before_staging), ThreadPoolExecutor(max_workers=2) as executor:
+            first = executor.submit(run_task)
+            try:
+                first_pid = worker_pids.get(timeout=5)
+                self.assertTrue(staging_started.wait(timeout=5))
+                second = executor.submit(run_task)
+                second_pid = worker_pids.get(timeout=5)
+
+                # Observe PostgreSQL blocking the second worker before either task stages the bot.
+                deadline = time.monotonic() + 5
+                blocked = False
+                while time.monotonic() < deadline and not second.done():
+                    with connection.cursor() as cursor:
+                        cursor.execute("SELECT %s = ANY(pg_blocking_pids(%s))", [first_pid, second_pid])
+                        blocked = cursor.fetchone()[0]
+                    if blocked:
+                        break
+                    time.sleep(0.01)
+                self.assertTrue(blocked, "The duplicate task did not wait for the first task's row lock")
+            finally:
+                release_staging.set()
+
+            first.result(timeout=10)
+            second.result(timeout=10)
+
+        bot.refresh_from_db()
+        self.assertEqual(bot.state, BotStates.STAGED)
+        self.assertEqual(bot.bot_events.filter(event_type=BotEventTypes.STAGED).count(), 1)
+        mock_launch_bot.assert_called_once_with(bot)

--- a/bots/tests/test_launch_scheduled_bot_task.py
+++ b/bots/tests/test_launch_scheduled_bot_task.py
@@ -37,6 +37,20 @@ class LaunchScheduledBotTaskTestCase(TestCase):
             # Verify launch_bot was called
             mock_launch_bot.assert_called_once_with(self.bot)
 
+    def test_duplicate_launch_scheduled_bot(self):
+        """A duplicate delivery after staging skips without launching again."""
+        with patch("bots.tasks.launch_scheduled_bot_task.launch_bot") as mock_launch_bot:
+            launch_scheduled_bot(self.bot.id, self.original_join_at.isoformat())
+            with self.assertLogs("bots.tasks.launch_scheduled_bot_task", level="INFO") as logs:
+                launch_scheduled_bot(self.bot.id, self.original_join_at.isoformat())
+
+        self.bot.refresh_from_db()
+        self.assertEqual(self.bot.state, BotStates.STAGED)
+        self.assertEqual(self.bot.bot_events.filter(event_type=BotEventTypes.STAGED).count(), 1)
+        mock_launch_bot.assert_called_once_with(self.bot)
+        self.assertTrue(any("is not in state SCHEDULED, skipping" in message for message in logs.output))
+        self.assertTrue(all(record.levelname == "INFO" for record in logs.records))
+
     def test_bot_not_in_scheduled_state(self):
         """Test that task exits early if bot is not in SCHEDULED state"""
         # Change bot state to READY
@@ -74,25 +88,18 @@ class LaunchScheduledBotTaskTestCase(TestCase):
 
     def test_join_at_modified_after_task_queued(self):
         """Test the race condition where join_at is modified between task queueing and execution"""
-
-        def mock_get_bot_and_modify_join_at(id, *args, **kwargs):
-            """Mock that simulates another process modifying join_at after we get the bot"""
-            bot = Bot.objects.filter(id=id).first()
-            # Simulate another process modifying the join_at field
-            Bot.objects.filter(id=id).update(join_at=self.modified_join_at)
-            return bot
+        Bot.objects.filter(id=self.bot.id).update(join_at=self.modified_join_at)
 
         with patch("bots.tasks.launch_scheduled_bot_task.launch_bot") as mock_launch_bot:
-            with patch("bots.models.Bot.objects.get", side_effect=mock_get_bot_and_modify_join_at):
-                # Execute the task with the original join_at time
-                # This should raise a ValidationError due to the join_at mismatch
-                with self.assertRaises(ValidationError) as context:
-                    launch_scheduled_bot(self.bot.id, self.original_join_at.isoformat())
+            # Execute the task with the original join_at time
+            # This should raise a ValidationError due to the join_at mismatch
+            with self.assertRaises(ValidationError) as context:
+                launch_scheduled_bot(self.bot.id, self.original_join_at.isoformat())
 
-                # Verify the error message contains the expected text
-                error_message = str(context.exception)
-                self.assertIn("join_at in event_metadata", error_message)
-                self.assertIn("is different from the join_at in the database", error_message)
+            # Verify the error message contains the expected text
+            error_message = str(context.exception)
+            self.assertIn("join_at in event_metadata", error_message)
+            self.assertIn("is different from the join_at in the database", error_message)
 
-                # Verify launch_bot was not called due to the error
-                mock_launch_bot.assert_not_called()
+            # Verify launch_bot was not called due to the error
+            mock_launch_bot.assert_not_called()


### PR DESCRIPTION
Two scheduler replicas can enqueue the same bot before either task stages it, causing a duplicate task to raise a ValidationError and trigger error alerts.

Lock the bot row while checking its state and creating the STAGED event so duplicate tasks skip safely. Launching happens after the lock is released.
