### PR TITLE
fix: stop the virtual display during web bot cleanup

### DIFF
--- a/bots/tests/test_virtual_display_teardown.py
+++ b/bots/tests/test_virtual_display_teardown.py
@@ -127,8 +127,8 @@ class VirtualDisplayTeardownProcessTest(unittest.TestCase):
 
         display = Display(visible=0, size=(1930, 1090), use_xauth=True)
         display.start()
-        self.addCleanup(lambda: _process_alive(pid) and display.stop())
         pid = display.pid
+        self.addCleanup(lambda: _process_alive(pid) and display.stop())
         self.assertTrue(_process_alive(pid), "Xvfb never started")
 
         adapter = build_adapter(display=display)

--- a/bots/tests/test_virtual_display_teardown.py
+++ b/bots/tests/test_virtual_display_teardown.py
@@ -1,0 +1,141 @@
+import shutil
+import sys
+import time
+import unittest
+from unittest.mock import MagicMock
+
+from bots.web_bot_adapter.web_bot_adapter import WebBotAdapter
+
+
+def build_adapter(*, display, debug_screen_recorder=None, stop_recording_screen_callback=None):
+    """A real WebBotAdapter with its methods, without running the 25-arg __init__.
+
+    __init__ only assigns attributes (it never launches selenium or a display), and cleanup()
+    only reads the attributes set below, so __new__ + setting them is enough to exercise the
+    actual code on a genuine instance. Note __init__ never assigns self.display at all - it's
+    only set in init() when no DISPLAY env var exists - so omitting it is a real state."""
+    adapter = WebBotAdapter.__new__(WebBotAdapter)
+    adapter.stop_recording_screen_callback = stop_recording_screen_callback
+    adapter.driver = None
+    adapter.last_websocket_message_processed_time = None
+    adapter.debug_screen_recorder = debug_screen_recorder if debug_screen_recorder is not None else MagicMock()
+    adapter.websocket_server = None
+    if display is not None:
+        adapter.display = display
+    return adapter
+
+
+class VirtualDisplayTeardownLogicTest(unittest.TestCase):
+    """The control flow of cleanup() around the virtual display. The display is a mock here (see
+    VirtualDisplayTeardownProcessTest for the real Xvfb); these tests pin down the ordering and
+    the error handling that keeps one failing teardown step from skipping the rest - cleanup()
+    runs at most once, because BotController.cleanup() guards it with cleaned_up."""
+
+    def test_display_is_stopped_during_cleanup(self):
+        display = MagicMock()
+        adapter = build_adapter(display=display)
+
+        adapter.cleanup()
+
+        display.stop.assert_called_once()
+
+    def test_display_is_stopped_after_the_debug_screen_recorder(self):
+        calls = []
+        display = MagicMock()
+        display.stop.side_effect = lambda: calls.append("display")
+        recorder = MagicMock()
+        recorder.stop.side_effect = lambda: calls.append("recorder")
+        adapter = build_adapter(display=display, debug_screen_recorder=recorder)
+
+        adapter.cleanup()
+
+        # The debug recorder is an x11grab ffmpeg reading this display, so it must stop first.
+        self.assertEqual(calls, ["recorder", "display"])
+
+    def test_cleanup_completes_when_display_stop_raises(self):
+        display = MagicMock()
+        display.stop.side_effect = RuntimeError("boom")
+        adapter = build_adapter(display=display)
+
+        adapter.cleanup()  # must not raise
+
+        display.stop.assert_called_once()
+        self.assertTrue(adapter.cleaned_up)
+
+    def test_display_is_still_stopped_when_debug_screen_recorder_raises(self):
+        display = MagicMock()
+        recorder = MagicMock()
+        recorder.stop.side_effect = RuntimeError("boom")
+        adapter = build_adapter(display=display, debug_screen_recorder=recorder)
+
+        adapter.cleanup()  # must not raise
+
+        display.stop.assert_called_once()
+        self.assertTrue(adapter.cleaned_up)
+
+    def test_display_is_still_stopped_when_stop_recording_callback_raises(self):
+        display = MagicMock()
+        stop_recording_screen_callback = MagicMock(side_effect=RuntimeError("boom"))
+        adapter = build_adapter(display=display, stop_recording_screen_callback=stop_recording_screen_callback)
+
+        adapter.cleanup()  # must not raise
+
+        stop_recording_screen_callback.assert_called_once()
+        display.stop.assert_called_once()
+        self.assertTrue(adapter.cleaned_up)
+
+    def test_cleanup_completes_when_there_is_no_display_attribute(self):
+        adapter = build_adapter(display=None)
+
+        self.assertFalse(hasattr(adapter, "display"))
+
+        adapter.cleanup()  # must not raise
+
+        self.assertTrue(adapter.cleaned_up)
+
+
+def _process_alive(pid):
+    """True if the pid names a live (non-zombie) process. Reads /proc so a reaped-but-not-yet
+    -waited zombie counts as dead, which is what we care about here."""
+    try:
+        with open(f"/proc/{pid}/stat") as stat_file:
+            state = stat_file.read().rsplit(") ", 1)[1].split(" ", 1)[0]
+    except FileNotFoundError:
+        return False
+    return state != "Z"
+
+
+def _wait_until_dead(pid, timeout=5):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if not _process_alive(pid):
+            return True
+        time.sleep(0.02)
+    return False
+
+
+@unittest.skipUnless(sys.platform.startswith("linux"), "Xvfb teardown is Linux-only")
+@unittest.skipUnless(shutil.which("Xvfb"), "Xvfb is not installed")
+class VirtualDisplayTeardownProcessTest(unittest.TestCase):
+    """Integration test: cleanup() must actually kill the real Xvfb process. Nothing here is
+    mocked, so this catches a display that is only detached rather than stopped. The CI image
+    installs xvfb and xauth (Dockerfile:50), so this runs in CI - a start failure is a failure,
+    never a skip, otherwise the test would pass having proved nothing."""
+
+    def test_real_xvfb_process_is_stopped(self):
+        from pyvirtualdisplay import Display
+
+        display = Display(visible=0, size=(1930, 1090), use_xauth=True)
+        display.start()
+        self.addCleanup(lambda: _process_alive(pid) and display.stop())
+        pid = display.pid
+        self.assertTrue(_process_alive(pid), "Xvfb never started")
+
+        adapter = build_adapter(display=display)
+        adapter.cleanup()
+
+        self.assertTrue(_wait_until_dead(pid), f"Xvfb pid {pid} survived cleanup")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/bots/web_bot_adapter/web_bot_adapter.py
+++ b/bots/web_bot_adapter/web_bot_adapter.py
@@ -1113,7 +1113,10 @@ class WebBotAdapter(BotAdapter):
 
     def cleanup(self):
         if self.stop_recording_screen_callback:
-            self.stop_recording_screen_callback()
+            try:
+                self.stop_recording_screen_callback()
+            except Exception as e:
+                logger.warning(f"Error stopping screen recording: {e}")
 
         try:
             logger.info("disable media sending")
@@ -1135,7 +1138,19 @@ class WebBotAdapter(BotAdapter):
             logger.warning(f"Error during cleanup: {e}")
 
         if self.debug_screen_recorder:
-            self.debug_screen_recorder.stop()
+            try:
+                self.debug_screen_recorder.stop()
+            except Exception as e:
+                logger.warning(f"Error stopping debug screen recorder: {e}")
+
+        # Stop the virtual display after the debug screen recorder, which is an x11grab ffmpeg
+        # reading it. stop() can raise if the display was never started or the Xvfb is already gone.
+        display = getattr(self, "display", None)
+        if display:
+            try:
+                display.stop()
+            except Exception as e:
+                logger.warning(f"Error stopping virtual display: {e}")
 
         # Properly shutdown the websocket server
         if self.websocket_server:


### PR DESCRIPTION
## Why merge now

`WebBotAdapter.init()` starts a `pyvirtualdisplay.Display` when no `DISPLAY` is set, but `cleanup()` closes the driver, the debug recorder and the websocket server and never stops it. `webpage_streamer.py:305` stops its own display; this path does not.

### Why it leaks rather than lingers

With `CELERY_WORKER_MAX_TASKS_PER_CHILD = 1` (`attendee/settings/base.py:208`, the default outside the Kubernetes and docker-compose-multi-host launch modes) the celery child process exits as soon as the bot finishes, so the un-stopped Xvfb is reparented to init and outlives everything.

This happens on **cleanly-completed runs**, not just crashes. Measured on a self-hosted worker 13.5 hours after a restart: 8 bots, all ended normally, 8 orphan `Xvfb` at PPID 1, ~23 MB `RssAnon` each. The worker we had before that restart carried 57.

The `xclip -selection clipboard` daemon that `human_copy_and_paste` forks (`google_meet_ui_methods.py:335`) is fixed by the same change: with its X server gone it logs `X connection to :NN broken` and exits within ~2 s. Checked twice, once with `SIGTERM` and once with `SIGKILL`, since `pyvirtualdisplay`'s `stop()` takes the `SIGKILL` path.

## What changed

Three small things in `cleanup()`:

1. `display.stop()`, guarded. `self.display` only exists when `init()` found no `DISPLAY` — `__init__` never assigns the attribute — hence `getattr`. And `stop()` can raise on its own: `XStartError` when the display was never started, or from its xauth teardown (`os.remove` plus env restore) on a display whose Xvfb is already gone. Neither may abort the rest of cleanup.

2. It is placed **after** `debug_screen_recorder.stop()`, because that recorder is an `x11grab` ffmpeg reading this display.

3. The two statements that precede it — `stop_recording_screen_callback()` and `debug_screen_recorder.stop()` — were the only unprotected ones in the function, so an exception in either skipped everything below, and `BotController.cleanup()`'s `cleanup_called` flag means there is no second attempt. They now get the same best-effort try/except the driver teardown and the websocket shutdown in this function already had.

## Tested

`bots/tests/test_virtual_display_teardown.py`, in the two layers `test_chromedriver_teardown.py` established for this same `cleanup()` path.

Logic layer: `stop()` is called; it is ordered after the debug recorder; cleanup finishes when `stop()` itself raises; cleanup finishes and still stops the display when the recorder or the screen-recording callback raises; nothing blows up when there is no display.

Process layer: start a real `Display()`, take its pid, run `cleanup()`, assert the process is gone. Skipped only where `Xvfb` is not installed — never for a start failure, so it cannot go green without having proved anything. The CI image installs `xvfb` and `xauth` (`Dockerfile:50`), so it runs there.

Against `main` without the production change: 4 failures and 2 errors out of 7, including the real-process one. With it, and together with the existing `test_chromedriver_teardown` suite: 20 tests, OK. `ruff check` and `ruff format --check` clean.

## Blast radius

One function, `WebBotAdapter.cleanup()`. No caller changes, no new dependency; every added statement is a best-effort teardown wrapped in try/except, so the worst case of a wrong guess here is the same leak we have today, not a new failure. `webpage_streamer.py` has its own display and is untouched.

### What this does not fix

Two paths still orphan a display, both out of scope here and worth their own look:

- The `BLOCKED_BY_PLATFORM_REPEATEDLY` branch in `bot_controller.py:2021-2028` deliberately skips cleanup ("we'll be restarting the pod"). That holds in Kubernetes launch mode, where the pod dies; in celery mode there is no pod to restart and the display is orphaned. Stopping just the display there, rather than running a full cleanup, may be the right follow-up.
- An exception inside `handle_redis_message` is swallowed by GLib, because it runs via `GLib.idle_add` (`bot_controller.py:1037`). If `adapter.init()` fails there after `display.start()` — `wait_for_websocket_server_to_start` has a 10 s timeout that raises — no teardown runs at all, and no `FATAL_ERROR` event is recorded either. That is a larger issue than the display.

Nothing here helps a `SIGKILL`, including the OOM killer taking the Xvfb or the 600 s watchdog in `BotController.cleanup()` force-terminating the worker.
