### PR TITLE
feat: add self-hosting deployment recipes for Docker and Kubernetes

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -1,0 +1,210 @@
+# =============================================================================================
+# Attendee -- production environment
+# =============================================================================================
+# Copy to `.env`, fill in every REPLACE_ME, and keep the result out of version control.
+#
+# Postgres, Redis and the S3 bucket are assumed to already exist as separate services.
+#
+# Sections marked [PATH A] apply only to the Docker/Celery deployment.
+# Sections marked [PATH B] apply only to the Kubernetes deployment.
+# Everything else applies to both. See DEPLOYMENT.md.
+# =============================================================================================
+
+
+# -- Generated secrets ------------------------------------------------------------------------
+# Generate ONCE, then treat as permanent:
+#     docker run --rm <image> python init_env.py
+#
+# CREDENTIALS_ENCRYPTION_KEY is the Fernet key that every stored third-party credential (Zoom,
+# Google, Teams OAuth) is encrypted with. If it changes, all of them become undecryptable and
+# have to be re-entered. Back it up somewhere other than the cluster.
+DJANGO_SECRET_KEY=REPLACE_ME
+CREDENTIALS_ENCRYPTION_KEY=REPLACE_ME
+
+
+# -- Django -----------------------------------------------------------------------------------
+# production = generic; there is also attendee.settings.production-gke for GKE, which differs
+# only in leaving HTTPS redirection to the ingress.
+DJANGO_SETTINGS_MODULE=attendee.settings.production
+
+# Public hostname, no scheme. Used to build links in outgoing email and in the dashboard.
+SITE_DOMAIN=attendee.example.com
+# Comma-separated. Must contain SITE_DOMAIN. Anything else gets 400 DisallowedHost.
+ALLOWED_HOSTS=attendee.example.com
+# Comma-separated, WITH scheme. Required or every dashboard form POST fails CSRF validation.
+CSRF_TRUSTED_ORIGINS=https://attendee.example.com
+
+# true => Django redirects HTTP to HTTPS itself and marks cookies Secure. Requires the proxy in
+# front to send X-Forwarded-Proto, which settings/production.py already trusts.
+DJANGO_SSL_REQUIRE=true
+
+TIME_ZONE=Asia/Riyadh
+
+# Closes public sign-up. Keep true for a private deployment -- otherwise anyone who can reach
+# the URL can create an account. Flip to false only long enough to register the first user
+# (or use `manage.py createsuperuser` and leave it true).
+DISABLE_SIGNUP=true
+
+
+# -- Postgres (external) ----------------------------------------------------------------------
+# Percent-encode reserved characters in the password (@ : / ? # [ ] are the usual offenders).
+DATABASE_URL=postgresql://attendee:REPLACE_ME@postgres.example.internal:5432/attendee
+POSTGRES_SSL_REQUIRE=true
+# Set true ONLY when connecting through a transaction-pooling pooler (PgBouncer in transaction
+# mode). Server-side cursors break there.
+DISABLE_SERVER_SIDE_CURSORS=false
+
+
+# -- Redis (external) -------------------------------------------------------------------------
+# Built from the platform's CACHE_DB_* values:
+#     redis://<CACHE_DB_USER>:<CACHE_DB_PASSWORD>@<CACHE_DB_HOST>:<CACHE_DB_PORT>/<db index>
+# With no username keep the leading colon:  redis://:password@host:6379/5
+# For TLS use rediss:// and set REDIS_SSL_REQUIREMENTS below.
+#
+# WARNING: the database index must NOT be the one Mawrid uses (its CACHE_DB_INDEX, normally 0).
+# Attendee's Celery and Mawrid's taskiq would otherwise share a keyspace and consume each
+# other's jobs. 5 is Attendee's own convention.
+REDIS_URL=redis://:REPLACE_ME@redis.example.internal:6379/5
+# none | optional | required -- only meaningful with rediss://
+# REDIS_SSL_REQUIREMENTS=required
+
+
+# -- Object storage (external, S3-compatible) -------------------------------------------------
+# Attendee reads AWS_* names. Values map from the platform's CLOUD_BUCKET_* variables:
+#     CLOUD_BUCKET_ACCESS_KEY_ID     -> AWS_ACCESS_KEY_ID
+#     CLOUD_BUCKET_SECRET_ACCESS_KEY -> AWS_SECRET_ACCESS_KEY
+#     CLOUD_BUCKET_REGION            -> AWS_DEFAULT_REGION
+#     CLOUD_BUCKET_ENDPOINT_URL      -> AWS_ENDPOINT_URL
+#     CLOUD_BUCKET_NAME              -> AWS_RECORDING_STORAGE_BUCKET_NAME
+STORAGE_PROTOCOL=s3
+AWS_ACCESS_KEY_ID=REPLACE_ME
+AWS_SECRET_ACCESS_KEY=REPLACE_ME
+AWS_DEFAULT_REGION=me-jeddah-1
+AWS_ENDPOINT_URL=https://REPLACE_WITH_NAMESPACE.compat.objectstorage.me-jeddah-1.oraclecloud.com
+
+# path | virtual. Non-AWS S3 endpoints (Oracle's compat endpoint, rustfs, MinIO) serve
+# <endpoint>/<bucket>/<key>; botocore defaults to folding the bucket into the hostname, which
+# does not resolve there. This defaults to `path` whenever AWS_ENDPOINT_URL is set -- pinned
+# here so it is explicit. Leave AWS_ENDPOINT_URL empty and drop this line for real AWS S3.
+AWS_S3_ADDRESSING_STYLE=path
+
+# The bucket must already exist; Attendee never creates it.
+AWS_RECORDING_STORAGE_BUCKET_NAME=REPLACE_ME
+# Optional separate buckets. Both fall back to the recording bucket when unset.
+# AWS_AUDIO_CHUNK_STORAGE_BUCKET_NAME=
+# AWS_BOT_DEBUG_SCREENSHOT_STORAGE_BUCKET_NAME=
+
+# Keeps per-participant audio out of Postgres.
+USE_REMOTE_STORAGE_FOR_AUDIO_CHUNKS=true
+FALLBACK_TO_DB_STORAGE_FOR_AUDIO_CHUNKS_IF_REMOTE_STORAGE_FAILS=true
+
+
+# -- Webhooks ---------------------------------------------------------------------------------
+# Mawrid registers an HTTPS callback per bot, so keep this true in production.
+REQUIRE_HTTPS_WEBHOOKS=true
+MAX_WEBHOOK_DELIVERY_ATTEMPTS=3
+DELIVER_WEBHOOK_VERIFY_SSL=true
+# Set only if outside services must reach Attendee on a different hostname than SITE_DOMAIN.
+# EXTERNAL_WEBHOOK_SITE_DOMAIN=
+
+
+# -- Email (account confirmation and password reset) ------------------------------------------
+# true => emails are printed to the container log instead of sent. Acceptable when
+# DISABLE_SIGNUP=true and users are created with `manage.py createsuperuser`.
+DISABLE_EMAIL=false
+EMAIL_HOST=smtp.mailgun.org
+EMAIL_HOST_USER=REPLACE_ME
+EMAIL_HOST_PASSWORD=REPLACE_ME
+DEFAULT_FROM_EMAIL=noreply@example.com
+SERVER_EMAIL=noreply@example.com
+# ERROR_REPORTS_RECEIVER_EMAIL_ADDRESS=ops@example.com
+
+
+# -- Observability ----------------------------------------------------------------------------
+ATTENDEE_LOG_LEVEL=INFO
+# json for structured logs; leave empty for plain text.
+ATTENDEE_LOG_FORMAT=json
+# Attaches a failed bot's own logs to its final event, visible in the dashboard. The single
+# most useful setting when diagnosing a bot that misbehaved inside a real meeting.
+SAVE_BOT_LOGS_TO_DASHBOARD=true
+STORE_INFRASTRUCTURE_INFORMATION_IN_BOT_EVENT_METADATA=true
+# Leave SENTRY_DSN empty to disable Sentry entirely.
+SENTRY_DSN=
+SENTRY_ENVIRONMENT=production
+SENTRY_TRACES_SAMPLE_RATE=0.1
+SENTRY_PROFILES_SAMPLE_RATE=0.1
+SENTRY_SEND_PII=false
+
+# Ceiling on simultaneously running bots across the whole deployment.
+CONCURRENT_BOTS_LIMIT=50
+
+# Heartbeat file the scheduler rewrites each cycle so a liveness probe can detect a stalled
+# loop. Harmless to set on both paths; only Kubernetes actually probes it.
+SCHEDULER_HEARTBEAT_FILE=/tmp/scheduler-heartbeat
+
+
+# =============================================================================================
+# [PATH A]  Docker / Celery deployment ONLY
+# =============================================================================================
+# Bots run inside the Celery worker container. LAUNCH_BOT_METHOD is deliberately ABSENT: the
+# code defaults to celery when it is unset. Do not set it to "celery" -- only the literal
+# values "kubernetes" and "docker-compose-multi-host" are recognised, and anything else falls
+# through to the same default, so leaving it out is the honest expression of intent.
+#
+# Image the compose file runs. Must be a tag the host can pull.
+ATTENDEE_IMAGE=registry.example.com/attendee:REPLACE_WITH_IMAGE_TAG
+#
+# Celery worker concurrency == how many bots one worker container can host at once. Size it at
+# roughly 4 vCPU and 4 GB of RAM per concurrent bot, and remember the app forcibly recycles the
+# worker process after every task (CELERY_WORKER_MAX_TASKS_PER_CHILD=1, a Zoom SDK segfault
+# workaround), so process startup cost is paid once per bot.
+CELERY_CONCURRENCY=2
+
+
+# =============================================================================================
+# [PATH B]  Kubernetes deployment ONLY
+# =============================================================================================
+# Makes the app create one isolated pod per bot instead of running bots in the workers.
+# LAUNCH_BOT_METHOD=kubernetes
+#
+# REQUIRED in Kubernetes mode -- BotPodCreator raises without it. Bot pods are launched as
+# "$BOT_POD_IMAGE:$CUBER_RELEASE_VERSION", so this MUST equal the image tag the Deployments
+# run. Bump both together on every release or the app and its bots diverge.
+# CUBER_RELEASE_VERSION=REPLACE_WITH_IMAGE_TAG
+# CUBER_APP_NAME=attendee
+# BOT_POD_IMAGE=registry.example.com/attendee
+# BOT_POD_IMAGE_PULL_POLICY=IfNotPresent
+#
+# Namespaces. Bot pods read their env from the ConfigMap and Secret named below, which live in
+# BOT_POD_NAMESPACE -- so the app and its bots must share that namespace.
+# BOT_POD_NAMESPACE=attendee
+# WEBPAGE_STREAMER_POD_NAMESPACE=attendee-webpage-streamer
+# BOT_POD_SERVICE_ACCOUNT_NAME=attendee-bot
+# WEBPAGE_STREAMER_POD_SERVICE_ACCOUNT_NAME=attendee-bot
+#
+# These two names are load-bearing: bot pods are built with envFrom referencing them, and the
+# reference is not optional. A mismatch leaves every bot pod in CreateContainerConfigError.
+# BOT_POD_CONFIG_MAP_NAME=env
+# BOT_POD_SECRETS_NAME=app-secrets
+#
+# false => bot pods reference the named image pull secret. true if the registry is public.
+# DISABLE_BOT_POD_IMAGE_PULL_SECRET=false
+# BOT_POD_IMAGE_PULL_SECRET_NAME=regcred
+#
+# Per-bot pod resources. Memory and ephemeral-storage are also the pod's limits.
+# BOT_CPU_REQUEST=4
+# BOT_MEMORY_REQUEST=4Gi
+# BOT_MEMORY_LIMIT=4Gi
+# BOT_EPHEMERAL_STORAGE_REQUEST=10Gi
+#
+# Lets bot pods call back to the app over cluster-internal DNS, bypassing the public ingress.
+# INTERNAL_SITE_DOMAIN=attendee-web.attendee.svc.cluster.local:8000
+#
+# Stops Karpenter from disrupting a pod mid-meeting. Set true on Karpenter clusters.
+# USING_KARPENTER=false
+# GKE equivalent:
+# USE_GKE_EXTENDED_DURATION_FOR_BOT_PODS=false
+#
+# Chrome sandboxing needs an Unconfined seccomp profile; only enable if PodSecurity admission
+# in the bot namespace permits it.
+# ENABLE_CHROME_SANDBOX=false

--- a/.env.selfhost.example
+++ b/.env.selfhost.example
@@ -1,0 +1,64 @@
+# =============================================================================================
+# Attendee -- LOCAL self-hosted development (selfhost.docker-compose.yaml)
+# =============================================================================================
+# Not for production. Postgres, Redis and object storage all run in the compose stack; rustfs
+# stands in for S3 so nothing has to reach a real cloud bucket to record a meeting.
+#
+#   cp .env.selfhost.example .env
+#   docker compose -f selfhost.docker-compose.yaml run --rm attendee-app python init_env.py
+#   # paste the two generated keys below, then:
+#   docker compose -f selfhost.docker-compose.yaml up -d
+# =============================================================================================
+
+
+# -- Generated secrets ------------------------------------------------------------------------
+# From `python init_env.py`. Any value works locally, but generate real ones so the encrypted
+# credential columns behave the same as in production.
+DJANGO_SECRET_KEY=REPLACE_ME
+CREDENTIALS_ENCRYPTION_KEY=REPLACE_ME
+
+
+# -- Django -----------------------------------------------------------------------------------
+DJANGO_SETTINGS_MODULE=attendee.settings.development
+# The app is published on host port 8100 (Mawrid's backend already holds 8000). SITE_DOMAIN has
+# to match, or the account-confirmation link printed in the logs points at the wrong port.
+SITE_DOMAIN=localhost:8100
+# host.docker.internal is needed so Mawrid's backend container can call in.
+ALLOWED_HOSTS=localhost,127.0.0.1,host.docker.internal
+DISABLE_SIGNUP=false
+
+
+# -- Postgres and Redis (in-stack) -------------------------------------------------------------
+# settings/development.py hardcodes the database name, user and password; only the host is
+# configurable, and selfhost.docker-compose.yaml already sets POSTGRES_HOST=postgres.
+# REDIS_URL is likewise set by the compose file (redis://redis:6379/5).
+
+
+# -- Object storage: rustfs ---------------------------------------------------------------------
+# rustfs boots with these same credentials (see selfhost.docker-compose.yaml), so they always
+# match. The bucket is created by the rustfs-init container -- Attendee never creates its own.
+#   S3 API from the host:     http://localhost:9100
+#   Web console:              http://localhost:9101
+STORAGE_PROTOCOL=s3
+AWS_ACCESS_KEY_ID=attendeeadmin
+AWS_SECRET_ACCESS_KEY=attendeeadmin
+AWS_DEFAULT_REGION=us-east-1
+# Reached over the compose network, not from the host.
+AWS_ENDPOINT_URL=http://rustfs:9000
+# rustfs serves path style only; botocore would otherwise try http://attendee.rustfs:9000.
+AWS_S3_ADDRESSING_STYLE=path
+AWS_RECORDING_STORAGE_BUCKET_NAME=attendee
+USE_REMOTE_STORAGE_FOR_AUDIO_CHUNKS=true
+FALLBACK_TO_DB_STORAGE_FOR_AUDIO_CHUNKS_IF_REMOTE_STORAGE_FAILS=true
+
+
+# -- Local-only relaxations ---------------------------------------------------------------------
+# Mawrid's callback is plain HTTP on host.docker.internal, which the default HTTPS-only rule
+# would reject.
+REQUIRE_HTTPS_WEBHOOKS=false
+DISABLE_EMAIL=true
+DISABLE_RATE_LIMITING=true
+ATTENDEE_LOG_LEVEL=INFO
+SAVE_BOT_LOGS_TO_DASHBOARD=true
+
+# LAUNCH_BOT_METHOD is intentionally unset: bots run inside the Celery worker container.

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,0 +1,525 @@
+# Deploying self-hosted Attendee
+
+Handover document for whoever operates this. It covers two supported production shapes:
+
+| | **Path A — Docker + Celery** | **Path B — Kubernetes** |
+|---|---|---|
+| Where a bot runs | inside the Celery worker container | in its own pod, one per bot |
+| Setup effort | low | moderate (RBAC, manifests) |
+| Bot isolation | none — bots share a container | full |
+| Effect of a worker restart | **every in-progress bot is killed** | app restarts don't touch running bots |
+| Scaling | vertical, one host | horizontal, cluster autoscaler |
+| Recommended for | pilots, low volume, single host | anything with real meeting load |
+
+Both paths assume **PostgreSQL, Redis and an S3-compatible bucket already exist as separate
+services**. Nothing in this repo provisions them.
+
+Attendee is a Django app. Every deployment is the *same image* run with three different
+commands — web, Celery worker, scheduler — plus, on Kubernetes, the bot pods the app creates
+at runtime.
+
+---
+
+## 1. Prerequisites
+
+### PostgreSQL
+- Version 15 or newer.
+- One dedicated database and role. The app owns its schema and runs its own migrations.
+- Reachable over TLS. `POSTGRES_SSL_REQUIRE=true` is the default and should stay on.
+- If you front it with **PgBouncer in transaction mode**, also set
+  `DISABLE_SERVER_SIDE_CURSORS=true` — server-side cursors do not survive transaction pooling.
+
+### Redis
+- Used as the Celery broker *and* result backend, plus some direct key access by the scheduler.
+- **Give Attendee its own database index.** If Mawrid points at the same Redis, Attendee must
+  not use Mawrid's `CACHE_DB_INDEX`. Sharing an index means Attendee's Celery and Mawrid's
+  taskiq write into one keyspace and will consume each other's jobs. Attendee's own convention
+  is index `5`.
+- The connection string is assembled from the platform's `CACHE_DB_*` values:
+  ```
+  REDIS_URL=redis://<CACHE_DB_USER>:<CACHE_DB_PASSWORD>@<CACHE_DB_HOST>:<CACHE_DB_PORT>/5
+  ```
+  With no username, keep the leading colon: `redis://:password@host:6379/5`.
+  For TLS use `rediss://` and set `REDIS_SSL_REQUIREMENTS=required`.
+
+### Object storage (S3-compatible)
+- **The bucket must already exist.** Attendee never creates it.
+- Credentials need `GetObject`, `PutObject`, `DeleteObject`, `ListBucket`, and multipart upload
+  permissions on that bucket. Recordings are streamed up as multipart.
+- Attendee reads `AWS_*` variable names. Map them from the platform's names:
+
+  | Platform variable | Attendee variable |
+  |---|---|
+  | `CLOUD_BUCKET_ACCESS_KEY_ID` | `AWS_ACCESS_KEY_ID` |
+  | `CLOUD_BUCKET_SECRET_ACCESS_KEY` | `AWS_SECRET_ACCESS_KEY` |
+  | `CLOUD_BUCKET_REGION` | `AWS_DEFAULT_REGION` |
+  | `CLOUD_BUCKET_ENDPOINT_URL` | `AWS_ENDPOINT_URL` |
+  | `CLOUD_BUCKET_NAME` | `AWS_RECORDING_STORAGE_BUCKET_NAME` |
+
+- **`AWS_S3_ADDRESSING_STYLE=path` is required for any non-AWS endpoint** (Oracle Object
+  Storage's `compat` endpoint, rustfs, MinIO, Ceph). Botocore's default folds the bucket name
+  into the hostname — `https://mybucket.<namespace>.compat.objectstorage...` — which those
+  endpoints do not serve. This fork defaults to `path` whenever `AWS_ENDPOINT_URL` is set; the
+  env file pins it explicitly so nobody has to rediscover it. Leave `AWS_ENDPOINT_URL` empty
+  and drop this variable if the bucket is genuinely on AWS S3.
+
+### Ingress / TLS
+- Terminate TLS in front of the app and **forward `X-Forwarded-Proto`**. Django's
+  `SECURE_PROXY_SSL_HEADER` depends on it; without it every request looks insecure and
+  `SECURE_SSL_REDIRECT` puts clients into a redirect loop.
+- Allow large request bodies (512 MB is a safe starting point) and a generous read timeout.
+
+---
+
+## 2. Build and publish the image
+
+The Dockerfile pins `--platform=linux/amd64`. Building on an ARM machine (Apple Silicon) works
+but emulates, and takes a long time — the image installs Chrome, the Zoom SDK, OpenCV and a
+build toolchain. Build on an amd64 runner where you can.
+
+```bash
+export TAG=$(date +%Y%m%d)-$(git rev-parse --short HEAD)
+docker build --platform=linux/amd64 -t registry.example.com/attendee:$TAG .
+docker push registry.example.com/attendee:$TAG
+```
+
+Keep `$TAG` — both paths need it, and on Kubernetes it must also be written into
+`CUBER_RELEASE_VERSION`.
+
+Generate the two permanent secrets once, from any build of the image:
+
+```bash
+docker run --rm registry.example.com/attendee:$TAG python init_env.py
+```
+
+It prints `CREDENTIALS_ENCRYPTION_KEY` and `DJANGO_SECRET_KEY`.
+
+> **`CREDENTIALS_ENCRYPTION_KEY` is not rotatable in place.** It is the Fernet key encrypting
+> every stored Zoom / Google / Teams OAuth credential. If it changes, all of them become
+> undecryptable and every integration has to be reconnected by hand. Back it up outside the
+> cluster.
+
+---
+
+## 3. Path A — Docker + Celery
+
+Bots run inside the Celery worker. Three containers, one image, external backing services.
+
+### 3.1 Configure
+
+```bash
+cp .env.production.example .env
+```
+
+Fill in every `REPLACE_ME`. Use the `[PATH A]` block at the bottom; leave the whole `[PATH B]`
+block commented out.
+
+**Leave `LAUNCH_BOT_METHOD` unset.** The code defaults to Celery when it is absent. Only the
+literal strings `kubernetes` and `docker-compose-multi-host` are recognised — setting it to
+`celery` happens to work but only because it falls through to the default, so omitting it is
+the honest expression of intent.
+
+### 3.2 Migrate, then start
+
+```bash
+docker compose -f prod.docker-compose.yaml pull
+docker compose -f prod.docker-compose.yaml run --rm attendee-web python manage.py migrate --noinput
+docker compose -f prod.docker-compose.yaml up -d
+```
+
+`prod.docker-compose.yaml` defines exactly three services. If you would rather run them as
+bare `docker run` units or under systemd, these are the commands:
+
+| Role | Command | Entrypoint |
+|---|---|---|
+| **web** | `python manage.py collectstatic --noinput && gunicorn attendee.wsgi --bind 0.0.0.0:8000 --workers 3 --timeout 120 --access-logfile -` | `/tini --` |
+| **worker** | `celery -A attendee worker -l INFO --concurrency 2` | **image default** |
+| **scheduler** | `python manage.py run_scheduler` | `/tini --` |
+
+The entrypoint column matters. The image's `ENTRYPOINT` is
+`["/tini","--","/usr/local/bin/entrypoint.sh"]`, and `entrypoint.sh` boots PulseAudio.
+
+- The **worker keeps the default entrypoint** — a bot with no audio device cannot join a
+  meeting.
+- Web and scheduler override it with `/tini --` so tini stays PID 1 (signal forwarding, zombie
+  reaping) while the audio setup is skipped.
+
+Give the worker container **`--shm-size=2g`**. Chrome crashes on Docker's 64 MB default.
+
+### 3.3 Sizing
+
+Concurrency is the number of bots one worker container can host at once.
+
+- Budget **≈ 4 vCPU and 4 GB RAM per concurrent bot** — each is a full Chrome plus PulseAudio.
+- Also budget disk: a bot records to local storage before upload, ~10 GB per concurrent bot.
+- The app forces `CELERY_WORKER_MAX_TASKS_PER_CHILD=1`, so the worker process is recreated
+  after every task. This is a deliberate workaround for a Zoom SDK segfault, not a
+  misconfiguration — it means process startup cost is paid once per bot.
+
+So `--concurrency 2` wants roughly an 8 vCPU / 16 GB host with 32 GB of free disk.
+
+### 3.4 Known limitations of this path
+
+Straight from the upstream README, and the reason Kubernetes is recommended at volume:
+
+1. **Bots are killed on restart.** Any deploy, scale, or crash of the worker container
+   terminates every bot currently sitting in a meeting. There is no drain.
+2. **No isolation between bots.** Bots in one container share audio devices, so audio from
+   separate meetings can bleed together.
+3. Any infrastructure problem with that container affects every bot on it.
+
+Plan deploys for quiet hours, or move to Path B.
+
+---
+
+## 4. Path B — Kubernetes
+
+The app talks to the Kubernetes API and creates **one pod per bot**. App restarts no longer
+touch running bots, and each bot is isolated.
+
+Manifests are in [`k8s/`](k8s/). They are plain YAML with a `kustomization.yaml` wrapper.
+
+### 4.1 What gets deployed
+
+| Manifest | Contents |
+|---|---|
+| `00-namespaces.yaml` | `attendee`, `attendee-webpage-streamer` |
+| `10-rbac.yaml` | `attendee-app` ServiceAccount + Roles; `attendee-bot` SA with no permissions |
+| `20-configmap-env.yaml` | ConfigMap **`env`** — all non-secret configuration |
+| `21-secret-app-secrets.yaml` | Secret **`app-secrets`** — template, do not commit filled in |
+| `30-deployment-web.yaml` | gunicorn, 2 replicas |
+| `31-deployment-worker.yaml` | Celery workers, 2 replicas |
+| `32-deployment-scheduler.yaml` | scheduler + failed-launch corrector, 1 replica each |
+| `40-service.yaml` | ClusterIP `attendee-web:8000` |
+| `41-ingress.yaml` | TLS ingress (nginx + cert-manager example) |
+| `50-job-migrate.yaml` | migration Job, run per release |
+| `60-cronjobs.yaml` | pod cleanup + stalled-bot cleanup + optional data retention |
+
+### 4.2 Three names that are load-bearing
+
+The app builds each bot pod in code, and the pod spec references config by name. Get these
+wrong and bots fail in ways that do not point at the cause.
+
+1. **ConfigMap must be named `env`** and **Secret must be named `app-secrets`** — or you must
+   set `BOT_POD_CONFIG_MAP_NAME` / `BOT_POD_SECRETS_NAME` to match. Bot pods are created with
+   `envFrom` referencing them, and the reference is *not* marked optional, so a mismatch
+   leaves every bot pod in `CreateContainerConfigError`.
+2. **They must live in `BOT_POD_NAMESPACE`** — the same namespace the bot pods run in. That is
+   why the app and its bots share the `attendee` namespace here.
+3. **`CUBER_RELEASE_VERSION` must equal the image tag.** Bot pods are launched as
+   `$BOT_POD_IMAGE:$CUBER_RELEASE_VERSION`. It is required — the app raises without it — and
+   Kustomize's image rewriting does *not* update ConfigMap values, so it must be bumped by
+   hand alongside `newTag` on every release. If they drift, the app runs one build and its
+   bots run another.
+
+### 4.3 RBAC
+
+The `attendee-app` ServiceAccount gets a namespaced Role, not a ClusterRole. Every verb is
+exercised by code in this repo:
+
+| Resource | Verbs | Used by |
+|---|---|---|
+| `pods` | `create` | `bots/bot_pod_creator/bot_pod_creator.py` |
+| `pods` | `get` | `bots/k8s_utils.py`, `bots/tasks/restart_bot_pod_task.py` |
+| `pods` | `list` | `clean_up_completed_bot_pods` |
+| `pods` | `delete` | pod cleanup, stalled-bot cleanup, `restart_bot_pod_task` |
+| `events` | `list` | `bots/k8s_utils.py` — attaches pod events to a bot's failure record |
+| `services` | `create` | streamer namespace only, for the webpage-streamer Service |
+
+Bot pods themselves never call the Kubernetes API, so they run as `attendee-bot`, which has no
+bindings and `automountServiceAccountToken: false`.
+
+### 4.4 Deploy
+
+```bash
+# 1. Registry credentials, in both namespaces bot pods can land in.
+kubectl create namespace attendee
+kubectl create namespace attendee-webpage-streamer
+for ns in attendee attendee-webpage-streamer; do
+  kubectl -n $ns create secret docker-registry regcred \
+    --docker-server=registry.example.com \
+    --docker-username=REPLACE_ME \
+    --docker-password=REPLACE_ME
+done
+
+# 2. Edit k8s/20-configmap-env.yaml and k8s/21-secret-app-secrets.yaml.
+#    Replace every REPLACE_ME, REPLACE_WITH_REGISTRY and REPLACE_WITH_IMAGE_TAG,
+#    and set the real hostname in the ConfigMap, the Ingress, and the web probes.
+
+# 3. Apply everything.
+kubectl apply -k k8s/
+
+# 4. Migrate before the rollout completes serving traffic.
+kubectl -n attendee delete job attendee-migrate --ignore-not-found
+kubectl -n attendee apply -f k8s/50-job-migrate.yaml
+kubectl -n attendee wait --for=condition=complete job/attendee-migrate --timeout=10m
+
+# 5. Watch it come up.
+kubectl -n attendee rollout status deployment/attendee-web
+kubectl -n attendee get pods
+```
+
+If you prefer generating config from an env file rather than editing YAML:
+
+```bash
+kubectl -n attendee create configmap env      --from-env-file=attendee.env
+kubectl -n attendee create secret generic app-secrets --from-env-file=attendee.secrets.env
+```
+
+### 4.5 Things that are easy to get wrong
+
+- **The scheduler must stay at `replicas: 1`.** Two schedulers double-launch every scheduled
+  bot. Its Deployment uses `strategy: Recreate` so a rollout never briefly runs two.
+- **The web probes send an explicit `Host` header.** `ALLOWED_HOSTS` does not contain the pod
+  IP, and kubelet uses the pod IP by default, which Django answers with `400 DisallowedHost`.
+  Update that header whenever you change the hostname. (A `301` from `SECURE_SSL_REDIRECT` on
+  the probe is expected and healthy — kubelet treats 2xx and 3xx as success.)
+- **The cleanup CronJobs are not optional.** Without them, completed bot pods accumulate
+  forever, and a bot whose pod dies mid-meeting is never marked failed — it hangs in
+  `launching` and its slot counts against `CONCURRENT_BOTS_LIMIT`.
+- **Bot pods need room to schedule.** Each requests 4 CPU / 4 Gi / 10 Gi ephemeral storage. On
+  a cluster without headroom or a fast autoscaler, bots miss the start of meetings. If you run
+  Karpenter, set `USING_KARPENTER=true` so it will not disrupt a pod mid-meeting.
+- **`attendee-webpage-streamer` must exist** even if you never stream webpages. The pod-cleanup
+  job sweeps both namespaces every run and will otherwise log errors continuously.
+
+---
+
+## 5. First run (both paths)
+
+1. Browse to `https://<SITE_DOMAIN>/`.
+2. Create the first account. Two options:
+   - Temporarily set `DISABLE_SIGNUP=false`, register through the UI, then set it back to
+     `true` and restart the web process. With `DISABLE_EMAIL=true` the confirmation link is
+     printed to the web container's log — retrieve it there.
+   - Or leave signup closed and run `python manage.py createsuperuser` in a one-off container.
+3. Create a project, then generate an **API key** from the project page.
+4. Copy the project's **webhook secret** (shown once).
+5. Health endpoints for monitoring: `GET /health/` returns 200; `GET /version/` returns the
+   app version and the `CUBER_RELEASE_VERSION` it is running.
+
+### Wiring Mawrid to it
+
+Set these in Mawrid's own `.env`:
+
+```
+ATTENDEE_HOST=https://attendee.example.com
+ATTENDEE_API_KEY=<the API key from step 3>
+ATTENDEE_WEBHOOK_SECRET=<the webhook secret from step 4>
+ATTENDEE_TRANSCRIPTION_SECRET=<any strong shared secret you generate>
+```
+
+`ATTENDEE_TRANSCRIPTION_SECRET` is the bearer token Attendee's Custom Async transcription
+provider presents when calling Mawrid's `POST /speech/attendee-transcribe`; configure the same
+value on the Attendee side in the project's transcription settings.
+
+Mawrid also supports `ATTENDEE_WEBHOOK_CALLBACK_HOST`, which overrides only the host of the
+callback URL Mawrid registers with Attendee. Leave it unset in production — it exists for local
+development, where the two stacks sit on separate Docker networks.
+
+---
+
+## 6. Upgrades
+
+```bash
+# Build and push the new tag, then:
+
+# Path A
+docker compose -f prod.docker-compose.yaml run --rm attendee-web python manage.py migrate --noinput
+docker compose -f prod.docker-compose.yaml up -d
+
+# Path B  (bump newTag in k8s/kustomization.yaml AND CUBER_RELEASE_VERSION in the ConfigMap)
+kubectl apply -k k8s/
+kubectl -n attendee delete job attendee-migrate --ignore-not-found
+kubectl -n attendee apply -f k8s/50-job-migrate.yaml
+kubectl -n attendee wait --for=condition=complete job/attendee-migrate --timeout=10m
+kubectl -n attendee rollout restart deployment/attendee-web deployment/attendee-worker
+```
+
+Migrations run before the new code serves traffic. On Path A, remember that restarting the
+worker kills bots that are currently in meetings.
+
+---
+
+## 7. Troubleshooting
+
+| Symptom | Cause |
+|---|---|
+| `SignatureDoesNotMatch` on upload | Custom S3 endpoint negotiating SigV2. This fork pins s3v4 on all S3 clients; check `AWS_ENDPOINT_URL` is set so that code path is taken. |
+| `NoSuchBucket` | The bucket does not exist. Attendee never creates it. |
+| Uploads fail with a DNS error naming `<bucket>.<endpoint>` | `AWS_S3_ADDRESSING_STYLE` is not `path`. |
+| `400 DisallowedHost` in web logs | Hostname missing from `ALLOWED_HOSTS`, or a probe sending the pod IP as `Host`. |
+| Dashboard form POSTs rejected | `CSRF_TRUSTED_ORIGINS` missing the scheme, or not set. |
+| Infinite HTTPS redirect loop | The proxy is not forwarding `X-Forwarded-Proto`. |
+| Bot pods stuck `CreateContainerConfigError` | ConfigMap `env` or Secret `app-secrets` missing from `BOT_POD_NAMESPACE`, or renamed without updating `BOT_POD_CONFIG_MAP_NAME` / `BOT_POD_SECRETS_NAME`. |
+| Bots never launch, app logs a `CUBER_RELEASE_VERSION` error | Unset. It is required in Kubernetes mode. |
+| Bot pods `ImagePullBackOff` | `regcred` missing in the bot namespace, or `BOT_POD_IMAGE`/`CUBER_RELEASE_VERSION` do not name a real tag. |
+| Bots stuck in `launching` forever | The stalled-bot cleanup CronJob is not running. |
+| Scheduled bots joining twice | More than one scheduler replica. |
+| Bot joins but records silence | Worker container is missing the default entrypoint, so PulseAudio never started. |
+| Chrome crashes inside a bot | `/dev/shm` too small — set `--shm-size=2g` (Path A). |
+| Attendee and Mawrid losing each other's jobs | Both pointed at the same Redis database index. |
+
+Useful commands:
+
+```bash
+kubectl -n attendee logs -l app.kubernetes.io/component=web --tail=200
+kubectl -n attendee get pods -l app=bot-proc            # live bot pods
+kubectl -n attendee describe pod <bot-pod>              # why a bot pod will not start
+kubectl -n attendee logs job/attendee-migrate
+```
+
+Attendee also records infrastructure detail against each bot when
+`STORE_INFRASTRUCTURE_INFORMATION_IN_BOT_EVENT_METADATA=true`, and attaches the bot's own logs
+to its final event when `SAVE_BOT_LOGS_TO_DASHBOARD=true`. Both are on in the supplied config
+and are usually faster than digging through cluster logs.
+
+---
+
+## 8. Local development
+
+Not production, but useful for reproducing a problem: `selfhost.docker-compose.yaml` runs the
+whole stack — app, worker, scheduler, Postgres, Redis — plus **rustfs** as a local
+S3-compatible store, so nothing has to reach a real bucket.
+
+```bash
+cp .env.selfhost.example .env
+docker compose -f selfhost.docker-compose.yaml build
+docker compose -f selfhost.docker-compose.yaml run --rm attendee-app python init_env.py
+# paste the two generated keys into .env, then:
+docker compose -f selfhost.docker-compose.yaml up -d
+docker compose -f selfhost.docker-compose.yaml exec attendee-app python manage.py migrate
+```
+
+Host ports are offset so this can run alongside Mawrid's own compose stack, which already holds
+8000, 5432, 6379, 9000 and 9001:
+
+- App — <http://localhost:8100>
+- rustfs S3 API — <http://localhost:9100>
+- rustfs console — <http://localhost:9101>
+
+Point Mawrid at it with `ATTENDEE_HOST=http://host.docker.internal:8100` and
+`ATTENDEE_WEBHOOK_CALLBACK_HOST=http://host.docker.internal:8000` — both stacks are on separate
+Docker networks, so neither can use `localhost` to reach the other.
+
+---
+
+## 9. Full environment variable reference
+
+`A` = Path A only, `B` = Path B only, `both` = required either way. The complete upstream list,
+including options not used here, is in [`docs/environment-variables.md`](docs/environment-variables.md).
+
+### Required
+
+| Variable | Path | Notes |
+|---|---|---|
+| `DJANGO_SECRET_KEY` | both | From `init_env.py`. |
+| `CREDENTIALS_ENCRYPTION_KEY` | both | From `init_env.py`. **Not rotatable** — encrypts stored OAuth credentials. |
+| `DJANGO_SETTINGS_MODULE` | both | `attendee.settings.production` |
+| `DATABASE_URL` | both | `postgresql://user:pass@host:5432/db`, password percent-encoded. |
+| `REDIS_URL` | both | Must use a DB index Mawrid does not use. |
+| `SITE_DOMAIN` | both | Public hostname, no scheme. |
+| `ALLOWED_HOSTS` | both | Comma-separated; must include `SITE_DOMAIN`. |
+| `CSRF_TRUSTED_ORIGINS` | both | Comma-separated, **with** scheme. |
+| `AWS_ACCESS_KEY_ID` | both | ← `CLOUD_BUCKET_ACCESS_KEY_ID` |
+| `AWS_SECRET_ACCESS_KEY` | both | ← `CLOUD_BUCKET_SECRET_ACCESS_KEY` |
+| `AWS_RECORDING_STORAGE_BUCKET_NAME` | both | ← `CLOUD_BUCKET_NAME`. Must already exist. |
+| `ATTENDEE_IMAGE` | A | Image tag the compose file runs. |
+| `LAUNCH_BOT_METHOD` | B | `kubernetes`. **Omit entirely on Path A.** |
+| `CUBER_RELEASE_VERSION` | B | Must equal the image tag. App raises without it. |
+| `BOT_POD_IMAGE` | B | Registry path, no tag. |
+
+### Storage
+
+| Variable | Default | Notes |
+|---|---|---|
+| `STORAGE_PROTOCOL` | `s3` | `s3` or `azure`. |
+| `AWS_DEFAULT_REGION` | `us-east-1` | ← `CLOUD_BUCKET_REGION` |
+| `AWS_ENDPOINT_URL` | — | ← `CLOUD_BUCKET_ENDPOINT_URL`. Empty for real AWS. |
+| `AWS_S3_ADDRESSING_STYLE` | `path` when endpoint set | Required for non-AWS endpoints. |
+| `AWS_AUDIO_CHUNK_STORAGE_BUCKET_NAME` | recording bucket | Optional split bucket. |
+| `AWS_BOT_DEBUG_SCREENSHOT_STORAGE_BUCKET_NAME` | recording bucket | Optional split bucket. |
+| `USE_REMOTE_STORAGE_FOR_AUDIO_CHUNKS` | `false` | `true` keeps audio out of Postgres. |
+| `FALLBACK_TO_DB_STORAGE_FOR_AUDIO_CHUNKS_IF_REMOTE_STORAGE_FAILS` | `false` | Safety net for the above. |
+
+### Database and Redis
+
+| Variable | Default | Notes |
+|---|---|---|
+| `POSTGRES_SSL_REQUIRE` | `true` | Leave on in production. |
+| `DISABLE_SERVER_SIDE_CURSORS` | `false` | `true` behind PgBouncer transaction pooling. |
+| `REDIS_SSL_REQUIREMENTS` | — | `none`/`optional`/`required`, for `rediss://`. |
+
+### Security and access
+
+| Variable | Default | Notes |
+|---|---|---|
+| `DJANGO_SSL_REQUIRE` | `true` | Needs `X-Forwarded-Proto` from the proxy. |
+| `DISABLE_SIGNUP` | `false` | **Set `true`** for a private deployment. |
+| `DISABLE_RATE_LIMITING` | `false` | Leave off in production. |
+| `PROJECT_POST_THROTTLE_RATE` | `3000/min` | Per-project API rate limit. |
+| `TIME_ZONE` | `UTC` | |
+
+### Bots — Path A
+
+| Variable | Default | Notes |
+|---|---|---|
+| `CELERY_CONCURRENCY` | `2` | Simultaneous bots per worker container. ~4 vCPU + 4 GB each. |
+| `CONCURRENT_BOTS_LIMIT` | `2500` | Deployment-wide ceiling. Lower it to match capacity. |
+
+### Bots — Path B
+
+| Variable | Default | Notes |
+|---|---|---|
+| `CUBER_APP_NAME` | `attendee` | Also used in pod labels. |
+| `BOT_POD_IMAGE_PULL_POLICY` | `Always` | `IfNotPresent` with immutable tags. |
+| `BOT_POD_NAMESPACE` | `attendee` | Must hold the ConfigMap and Secret. |
+| `WEBPAGE_STREAMER_POD_NAMESPACE` | `attendee-webpage-streamer` | Must exist. |
+| `BOT_POD_SERVICE_ACCOUNT_NAME` | `default` | Set to `attendee-bot`. |
+| `BOT_POD_CONFIG_MAP_NAME` | `env` | Must name a real ConfigMap in the bot namespace. |
+| `BOT_POD_SECRETS_NAME` | `app-secrets` | Must name a real Secret in the bot namespace. |
+| `DISABLE_BOT_POD_IMAGE_PULL_SECRET` | `false` | `true` for a public registry. |
+| `BOT_POD_IMAGE_PULL_SECRET_NAME` | `regcred` | |
+| `BOT_CPU_REQUEST` | `4` | |
+| `BOT_MEMORY_REQUEST` / `BOT_MEMORY_LIMIT` | `4Gi` | |
+| `BOT_EPHEMERAL_STORAGE_REQUEST` | `10Gi` | Also the limit. |
+| `INTERNAL_SITE_DOMAIN` | — | In-cluster callback address; bypasses the ingress. |
+| `USING_KARPENTER` | `false` | `true` stops mid-meeting disruption. |
+| `USE_GKE_EXTENDED_DURATION_FOR_BOT_PODS` | `false` | GKE equivalent. |
+| `ENABLE_CHROME_SANDBOX` | `false` | Needs an Unconfined seccomp profile. |
+| `BOT_POD_SPEC_DEFAULT` / `BOT_POD_SPEC_SCHEDULED` | — | JSON6902 patch applied to the generated pod spec, for node selectors, tolerations, etc. |
+
+### Webhooks
+
+| Variable | Default | Notes |
+|---|---|---|
+| `REQUIRE_HTTPS_WEBHOOKS` | `true` | `false` only for local development. |
+| `MAX_WEBHOOK_DELIVERY_ATTEMPTS` | `3` | |
+| `DELIVER_WEBHOOK_VERIFY_SSL` | `true` | |
+| `GLOBAL_WEBHOOK_DELIVERIES_PER_SECOND_RATE_LIMIT` | — | Unset = no limit. |
+| `EXTERNAL_WEBHOOK_SITE_DOMAIN` | `SITE_DOMAIN` | Only if outside services use a different hostname. |
+
+### Email
+
+| Variable | Default | Notes |
+|---|---|---|
+| `DISABLE_EMAIL` | `false` | `true` prints to the container log. |
+| `EMAIL_HOST` | `smtp.mailgun.org` | Port 587 with TLS is hardcoded. |
+| `EMAIL_HOST_USER` / `EMAIL_HOST_PASSWORD` | — | Required unless email is disabled. |
+| `DEFAULT_FROM_EMAIL` / `SERVER_EMAIL` | `noreply@mail.attendee.dev` | Change these. |
+| `ERROR_REPORTS_RECEIVER_EMAIL_ADDRESS` | — | Receives Django error mail. |
+
+### Observability
+
+| Variable | Default | Notes |
+|---|---|---|
+| `ATTENDEE_LOG_LEVEL` | `INFO` | |
+| `ATTENDEE_LOG_FORMAT` | — | `json` for structured logs. |
+| `SAVE_BOT_LOGS_TO_DASHBOARD` | `false` | `true` — very useful for diagnosing bots. |
+| `STORE_INFRASTRUCTURE_INFORMATION_IN_BOT_EVENT_METADATA` | `true` | Records pod status/events on failures. |
+| `SCHEDULER_HEARTBEAT_FILE` | — | Enables the scheduler liveness probe. |
+| `SENTRY_DSN` | — | Empty disables Sentry. |
+| `SENTRY_ENVIRONMENT` | `production` | |
+| `SENTRY_TRACES_SAMPLE_RATE` / `SENTRY_PROFILES_SAMPLE_RATE` | `0.1` | |
+| `SENTRY_SEND_PII` | `false` | Leave off — transcripts are PII. |
+| `MASK_TRANSCRIPT_IN_LOGS` | `false` | `true` if transcripts must not appear in logs. |

--- a/attendee/settings/base.py
+++ b/attendee/settings/base.py
@@ -342,8 +342,17 @@ STORAGES = {
     },
 }
 AWS_S3_SIGNATURE_VERSION = "s3v4"
+# Addressing style for S3 requests. Botocore folds the bucket into the hostname by default
+# (<bucket>.<endpoint>), which is what AWS serves but not what S3-compatible servers do --
+# rustfs, MinIO and Oracle Object Storage's `compat` endpoint serve path style
+# (<endpoint>/<bucket>/<key>). So a custom AWS_ENDPOINT_URL defaults to "path" here, real AWS
+# keeps botocore's own default, and AWS_S3_ADDRESSING_STYLE overrides either.
 if os.getenv("USE_IRSA_FOR_S3_STORAGE", "false") == "true":
     AWS_S3_ADDRESSING_STYLE = "virtual"
+elif os.getenv("AWS_S3_ADDRESSING_STYLE"):
+    AWS_S3_ADDRESSING_STYLE = os.getenv("AWS_S3_ADDRESSING_STYLE")
+elif os.getenv("AWS_ENDPOINT_URL"):
+    AWS_S3_ADDRESSING_STYLE = "path"
 
 CHARGE_CREDITS_FOR_BOTS = os.getenv("CHARGE_CREDITS_FOR_BOTS", "false") == "true"
 

--- a/attendee/settings/development.py
+++ b/attendee/settings/development.py
@@ -3,7 +3,9 @@ import os
 from .base import *
 
 DEBUG = True
-SITE_DOMAIN = "localhost:8000"
+# Env-driven so the app can be published on a port other than 8000 without the account
+# confirmation and dashboard links pointing at the wrong one.
+SITE_DOMAIN = os.getenv("SITE_DOMAIN", "localhost:8000")
 ALLOWED_HOSTS = os.getenv("ALLOWED_HOSTS", "localhost").split(",")
 
 DATABASES = {

--- a/bots/bot_controller/s3_client_config.py
+++ b/bots/bot_controller/s3_client_config.py
@@ -1,0 +1,33 @@
+import os
+
+from botocore.config import Config
+
+
+def s3_addressing_style(endpoint_url: str | None) -> str:
+    """Addressing style boto3 should use for `endpoint_url`.
+
+    AWS serves virtual-hosted style (``<bucket>.s3.<region>.amazonaws.com``), and botocore
+    folds the bucket into the hostname by default -- including when pointed at a custom
+    endpoint. S3-compatible servers (rustfs, MinIO, Oracle Object Storage's ``compat``
+    endpoint) generally only serve path style (``<endpoint>/<bucket>/<key>``), so a custom
+    endpoint defaults to "path" here. ``AWS_S3_ADDRESSING_STYLE`` overrides either way, and
+    matches the Django setting of the same name used by the django-storages backends.
+    """
+    configured = os.getenv("AWS_S3_ADDRESSING_STYLE")
+    if configured:
+        return configured
+    return "path" if endpoint_url else "auto"
+
+
+def s3_client_config(endpoint_url: str | None) -> Config:
+    """Botocore config shared by the raw boto3 clients that upload bot media.
+
+    signature_version is pinned to s3v4 because botocore otherwise negotiates SigV2 against a
+    custom ``endpoint_url``, which S3-compatible servers reject with SignatureDoesNotMatch.
+    The django-storages backends already get this from ``AWS_S3_SIGNATURE_VERSION`` in
+    settings; these clients bypass Django settings entirely, so they set it themselves.
+    """
+    return Config(
+        signature_version="s3v4",
+        s3={"addressing_style": s3_addressing_style(endpoint_url)},
+    )

--- a/bots/bot_controller/s3_file_uploader.py
+++ b/bots/bot_controller/s3_file_uploader.py
@@ -4,6 +4,8 @@ from pathlib import Path
 
 import boto3
 
+from .s3_client_config import s3_client_config
+
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
@@ -16,7 +18,7 @@ class S3FileUploader:
             bucket (str): The name of the S3 bucket to upload to
             filename (str): The name of the to be stored file
         """
-        self.s3_client = boto3.client("s3", endpoint_url=endpoint_url, region_name=region_name, aws_access_key_id=access_key_id, aws_secret_access_key=access_key_secret)
+        self.s3_client = boto3.client("s3", endpoint_url=endpoint_url, region_name=region_name, aws_access_key_id=access_key_id, aws_secret_access_key=access_key_secret, config=s3_client_config(endpoint_url))
         self.bucket = bucket
         self.filename = filename
         self._upload_thread = None

--- a/bots/bot_controller/streaming_uploader.py
+++ b/bots/bot_controller/streaming_uploader.py
@@ -6,12 +6,15 @@ from queue import Queue
 
 import boto3
 
+from .s3_client_config import s3_client_config
+
 logger = logging.getLogger(__name__)
 
 
 class StreamingUploader:
     def __init__(self, bucket, key, chunk_size=5242880):  # 5MB chunks
-        self.s3_client = boto3.client("s3", endpoint_url=os.getenv("AWS_ENDPOINT_URL"))
+        endpoint_url = os.getenv("AWS_ENDPOINT_URL")
+        self.s3_client = boto3.client("s3", endpoint_url=endpoint_url, config=s3_client_config(endpoint_url))
         self.bucket = bucket
         self.key = key
         self.chunk_size = chunk_size

--- a/k8s/00-namespaces.yaml
+++ b/k8s/00-namespaces.yaml
@@ -1,0 +1,16 @@
+# Two namespaces. `attendee` runs the app (web/worker/scheduler) AND the per-bot pods the app
+# creates at runtime -- they must share a namespace because bot pods read their environment
+# from the `env` ConfigMap and `app-secrets` Secret that live here (see 20-/21-).
+#
+# `attendee-webpage-streamer` only receives pods when a bot streams a webpage into a meeting
+# (voice agents). Create it regardless: clean_up_completed_bot_pods sweeps both namespaces on
+# every run, so a missing one is permanent noise in the logs.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: attendee
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: attendee-webpage-streamer

--- a/k8s/10-rbac.yaml
+++ b/k8s/10-rbac.yaml
@@ -1,0 +1,93 @@
+# The app creates, inspects and deletes bot pods through the Kubernetes API, so it needs a
+# ServiceAccount with real permissions. Every verb below is exercised by code in the fork:
+#
+#   pods    create  bots/bot_pod_creator/bot_pod_creator.py  (create_namespaced_pod)
+#           get     bots/k8s_utils.py, bots/tasks/restart_bot_pod_task.py (read_namespaced_pod)
+#           list    bots/management/commands/clean_up_completed_bot_pods.py
+#           delete  clean_up_completed_bot_pods, restart_bot_pod_task,
+#                   clean_up_bots_with_heartbeat_timeout_or_that_never_launched
+#   events  list    bots/k8s_utils.py -- attaches pod events to a bot's failure record
+#   services create bot_pod_creator, for the webpage-streamer pod only
+#
+# Scope is deliberately Role (namespaced), not ClusterRole: nothing here needs cluster-wide
+# reach, and a compromised app pod should not be able to enumerate pods elsewhere.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: attendee-app
+  namespace: attendee
+---
+# Bot pods run untrusted meeting content through a browser. They never call the Kubernetes API,
+# so they get their own identity with no bindings and no mounted token.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: attendee-bot
+  namespace: attendee
+automountServiceAccountToken: false
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: attendee-bot
+  namespace: attendee-webpage-streamer
+automountServiceAccountToken: false
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: attendee-bot-pod-manager
+  namespace: attendee
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["create", "get", "list", "delete"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: attendee-bot-pod-manager
+  namespace: attendee
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: attendee-bot-pod-manager
+subjects:
+  - kind: ServiceAccount
+    name: attendee-app
+    namespace: attendee
+---
+# Same permissions in the streamer namespace, plus `services`: the streamer pod is fronted by a
+# Service so the bot pod can reach it, created with an ownerReference so it dies with the pod.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: attendee-bot-pod-manager
+  namespace: attendee-webpage-streamer
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["create", "get", "list", "delete"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list"]
+  - apiGroups: [""]
+    resources: ["services"]
+    verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: attendee-bot-pod-manager
+  namespace: attendee-webpage-streamer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: attendee-bot-pod-manager
+subjects:
+  - kind: ServiceAccount
+    name: attendee-app
+    namespace: attendee

--- a/k8s/20-configmap-env.yaml
+++ b/k8s/20-configmap-env.yaml
@@ -1,0 +1,123 @@
+# NON-SECRET configuration.
+#
+# The name `env` is not cosmetic: bot pods are built at runtime with
+#   envFrom: [configMapRef: {name: $BOT_POD_CONFIG_MAP_NAME}]   (default "env")
+# and that reference is not optional -- rename this without also setting
+# BOT_POD_CONFIG_MAP_NAME and every bot pod dies in CreateContainerConfigError.
+#
+# Equivalent to: kubectl -n attendee create configmap env --from-env-file=attendee.env
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: env
+  namespace: attendee
+data:
+  # ── Django ────────────────────────────────────────────────────────────────────────────
+  DJANGO_SETTINGS_MODULE: "attendee.settings.production"
+  # Public hostname. SITE_DOMAIN builds the links in outgoing email and the dashboard.
+  SITE_DOMAIN: "attendee.example.com"
+  ALLOWED_HOSTS: "attendee.example.com"
+  CSRF_TRUSTED_ORIGINS: "https://attendee.example.com"
+  # true => Django issues its own HTTP->HTTPS redirect and sets Secure cookies. Keep true when
+  # the ingress terminates TLS and forwards X-Forwarded-Proto (SECURE_PROXY_SSL_HEADER is
+  # already wired up in attendee/settings/production.py).
+  DJANGO_SSL_REQUIRE: "true"
+  TIME_ZONE: "Asia/Riyadh"
+  # Closes public registration. Leave "true" for a private deployment -- the signup page is
+  # otherwise open to anyone who can reach the ingress. Set "false" only while creating the
+  # first account, then set it back and roll the web deployment.
+  DISABLE_SIGNUP: "true"
+
+  # ── Postgres (external) ───────────────────────────────────────────────────────────────
+  # The URL itself is a secret and lives in app-secrets as DATABASE_URL.
+  POSTGRES_SSL_REQUIRE: "true"
+  # Set "true" only behind a transaction-pooling pooler (PgBouncer in transaction mode).
+  DISABLE_SERVER_SIDE_CURSORS: "false"
+
+  # ── Object storage: Oracle Cloud Object Storage, S3-compatible ────────────────────────
+  # Attendee reads AWS_* names; the values come from Mawrid's CLOUD_BUCKET_* variables.
+  #   CLOUD_BUCKET_REGION       -> AWS_DEFAULT_REGION
+  #   CLOUD_BUCKET_ENDPOINT_URL -> AWS_ENDPOINT_URL
+  #   CLOUD_BUCKET_NAME         -> AWS_RECORDING_STORAGE_BUCKET_NAME
+  # (the two key variables map into app-secrets, below)
+  STORAGE_PROTOCOL: "s3"
+  AWS_DEFAULT_REGION: "me-jeddah-1"
+  AWS_ENDPOINT_URL: "https://REPLACE_WITH_NAMESPACE.compat.objectstorage.me-jeddah-1.oraclecloud.com"
+  # Oracle's compat endpoint serves path style (<endpoint>/<bucket>/<key>); botocore would
+  # otherwise put the bucket in the hostname and every upload would fail to resolve. This is
+  # the default whenever AWS_ENDPOINT_URL is set, and is pinned here so it is visible.
+  AWS_S3_ADDRESSING_STYLE: "path"
+  AWS_RECORDING_STORAGE_BUCKET_NAME: "attendee-recordings"
+  # Optional split buckets; both fall back to the recording bucket when unset.
+  # AWS_AUDIO_CHUNK_STORAGE_BUCKET_NAME: ""
+  # AWS_BOT_DEBUG_SCREENSHOT_STORAGE_BUCKET_NAME: ""
+  USE_REMOTE_STORAGE_FOR_AUDIO_CHUNKS: "true"
+  FALLBACK_TO_DB_STORAGE_FOR_AUDIO_CHUNKS_IF_REMOTE_STORAGE_FAILS: "true"
+
+  # ── Bot launching (Kubernetes mode) ───────────────────────────────────────────────────
+  # This is what makes the app create one isolated pod per bot instead of running bots inside
+  # the celery workers.
+  LAUNCH_BOT_METHOD: "kubernetes"
+  CUBER_APP_NAME: "attendee"
+  # REQUIRED, and the app refuses to start bot pods without it. Bot pods are launched as
+  # "$BOT_POD_IMAGE:$CUBER_RELEASE_VERSION", so this MUST equal the image tag the deployments
+  # below are running -- bump both together on every release.
+  CUBER_RELEASE_VERSION: "REPLACE_WITH_IMAGE_TAG"
+  BOT_POD_IMAGE: "REPLACE_WITH_REGISTRY/attendee"
+  BOT_POD_IMAGE_PULL_POLICY: "IfNotPresent"
+  BOT_POD_NAMESPACE: "attendee"
+  WEBPAGE_STREAMER_POD_NAMESPACE: "attendee-webpage-streamer"
+  BOT_POD_SERVICE_ACCOUNT_NAME: "attendee-bot"
+  WEBPAGE_STREAMER_POD_SERVICE_ACCOUNT_NAME: "attendee-bot"
+  # Names of THIS ConfigMap and the Secret; bot pods inherit their env from both.
+  BOT_POD_CONFIG_MAP_NAME: "env"
+  BOT_POD_SECRETS_NAME: "app-secrets"
+  # "false" => bot pods reference the `regcred` pull secret (see README). Set "true" if the
+  # image lives in a public registry or the nodes authenticate to it themselves.
+  DISABLE_BOT_POD_IMAGE_PULL_SECRET: "false"
+  BOT_POD_IMAGE_PULL_SECRET_NAME: "regcred"
+  # Per-bot resources. A bot runs a full Chrome plus PulseAudio and records to local disk, so
+  # these are large by design; memory and ephemeral-storage are also the pod's limits.
+  BOT_CPU_REQUEST: "4"
+  BOT_MEMORY_REQUEST: "4Gi"
+  BOT_MEMORY_LIMIT: "4Gi"
+  BOT_EPHEMERAL_STORAGE_REQUEST: "10Gi"
+  # Ceiling on simultaneously running bots across the whole deployment.
+  CONCURRENT_BOTS_LIMIT: "50"
+  # Set "true" on clusters using Karpenter so it will not disrupt a pod mid-meeting.
+  USING_KARPENTER: "false"
+  # Chrome sandboxing needs an Unconfined seccomp profile; leave false unless you have
+  # confirmed your PodSecurity admission level permits it.
+  ENABLE_CHROME_SANDBOX: "false"
+  # Attaches the bot's own logs to its final event, visible in the dashboard. Very useful when
+  # diagnosing a bot that failed inside a real meeting.
+  SAVE_BOT_LOGS_TO_DASHBOARD: "true"
+  STORE_INFRASTRUCTURE_INFORMATION_IN_BOT_EVENT_METADATA: "true"
+
+  # ── Webhooks ──────────────────────────────────────────────────────────────────────────
+  # Mawrid registers an HTTPS callback per bot, so this stays true in production.
+  REQUIRE_HTTPS_WEBHOOKS: "true"
+  # Bot pods call back to the app over this in-cluster address, bypassing the public ingress.
+  INTERNAL_SITE_DOMAIN: "attendee-web.attendee.svc.cluster.local:8000"
+  MAX_WEBHOOK_DELIVERY_ATTEMPTS: "3"
+  DELIVER_WEBHOOK_VERIFY_SSL: "true"
+
+  # ── Email (account confirmation + password reset) ─────────────────────────────────────
+  # "true" prints emails to the pod log instead of sending them. Fine if DISABLE_SIGNUP=true
+  # and you create users with `manage.py createsuperuser`; otherwise configure SMTP.
+  DISABLE_EMAIL: "false"
+  EMAIL_HOST: "smtp.mailgun.org"
+  DEFAULT_FROM_EMAIL: "noreply@example.com"
+  SERVER_EMAIL: "noreply@example.com"
+
+  # ── Observability ─────────────────────────────────────────────────────────────────────
+  ATTENDEE_LOG_LEVEL: "INFO"
+  # "json" emits structured logs; leave empty for plain text.
+  ATTENDEE_LOG_FORMAT: "json"
+  # File the scheduler rewrites each cycle. The scheduler's liveness probe reads its mtime, so
+  # a stalled polling loop gets the pod restarted -- a plain process check would not catch it.
+  SCHEDULER_HEARTBEAT_FILE: "/tmp/scheduler-heartbeat"
+  SENTRY_ENVIRONMENT: "production"
+  SENTRY_TRACES_SAMPLE_RATE: "0.1"
+  SENTRY_PROFILES_SAMPLE_RATE: "0.1"
+  SENTRY_SEND_PII: "false"

--- a/k8s/21-secret-app-secrets.yaml
+++ b/k8s/21-secret-app-secrets.yaml
@@ -1,0 +1,51 @@
+# SECRET configuration. Same naming rule as the ConfigMap: bot pods are created with
+#   envFrom: [secretRef: {name: $BOT_POD_SECRETS_NAME}]   (default "app-secrets")
+# and the reference is not optional.
+#
+# This file is a TEMPLATE and must not be committed with real values. Either apply it once by
+# hand, or (better) generate it from your secret manager. stringData takes plain text; the API
+# server base64-encodes it.
+#
+#   kubectl -n attendee create secret generic app-secrets \
+#     --from-env-file=attendee.secrets.env
+apiVersion: v1
+kind: Secret
+metadata:
+  name: app-secrets
+  namespace: attendee
+type: Opaque
+stringData:
+  # ── Django ────────────────────────────────────────────────────────────────────────────
+  # Both are generated once and then NEVER rotated casually:
+  #   docker run --rm <image> python init_env.py
+  # CREDENTIALS_ENCRYPTION_KEY is the Fernet key every stored third-party credential (Zoom,
+  # Google, Teams) is encrypted with. Change it and all of them become undecryptable.
+  DJANGO_SECRET_KEY: "REPLACE_ME"
+  CREDENTIALS_ENCRYPTION_KEY: "REPLACE_ME"
+
+  # ── Postgres (external) ───────────────────────────────────────────────────────────────
+  # Percent-encode any reserved characters in the password.
+  DATABASE_URL: "postgresql://attendee:REPLACE_ME@postgres.example.internal:5432/attendee"
+
+  # ── Redis (external) ──────────────────────────────────────────────────────────────────
+  # Built from Mawrid's CACHE_DB_* variables:
+  #   redis://<CACHE_DB_USER>:<CACHE_DB_PASSWORD>@<CACHE_DB_HOST>:<CACHE_DB_PORT>/<db index>
+  # With no username, keep the colon: redis://:password@host:6379/5
+  # Use rediss:// for TLS, and add REDIS_SSL_REQUIREMENTS=required to the ConfigMap.
+  #
+  # ⚠ The database index MUST NOT be the one Mawrid uses (its CACHE_DB_INDEX). Attendee's
+  # Celery and Mawrid's taskiq would otherwise share a keyspace and consume each other's jobs.
+  REDIS_URL: "redis://:REPLACE_ME@redis.example.internal:6379/5"
+
+  # ── Object storage (external, Oracle S3-compatible) ───────────────────────────────────
+  #   CLOUD_BUCKET_ACCESS_KEY_ID     -> AWS_ACCESS_KEY_ID
+  #   CLOUD_BUCKET_SECRET_ACCESS_KEY -> AWS_SECRET_ACCESS_KEY
+  AWS_ACCESS_KEY_ID: "REPLACE_ME"
+  AWS_SECRET_ACCESS_KEY: "REPLACE_ME"
+
+  # ── Email ─────────────────────────────────────────────────────────────────────────────
+  EMAIL_HOST_USER: "REPLACE_ME"
+  EMAIL_HOST_PASSWORD: "REPLACE_ME"
+
+  # ── Sentry (optional; omit the key entirely to disable) ───────────────────────────────
+  SENTRY_DSN: ""

--- a/k8s/30-deployment-web.yaml
+++ b/k8s/30-deployment-web.yaml
@@ -1,0 +1,62 @@
+# The Django web app. Stateless -- scale replicas freely.
+#
+# Note the `command` override. The image's ENTRYPOINT is ["/tini","--","entrypoint.sh"], and
+# entrypoint.sh boots PulseAudio, which only bot processes need. Keeping /tini as PID 1 (proper
+# signal forwarding and zombie reaping) while skipping the audio setup mirrors what the
+# upstream dev compose does with `entrypoint: []`.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: attendee-web
+  namespace: attendee
+  labels: {app.kubernetes.io/name: attendee, app.kubernetes.io/component: web}
+spec:
+  replicas: 2
+  selector:
+    matchLabels: {app.kubernetes.io/name: attendee, app.kubernetes.io/component: web}
+  template:
+    metadata:
+      labels: {app.kubernetes.io/name: attendee, app.kubernetes.io/component: web}
+    spec:
+      serviceAccountName: attendee-app
+      imagePullSecrets: [{name: regcred}]
+      containers:
+        - name: web
+          image: REPLACE_WITH_REGISTRY/attendee:REPLACE_WITH_IMAGE_TAG
+          command: ["/tini", "--", "sh", "-c"]
+          # collectstatic at startup: the image ships an empty, writable STATIC_ROOT and
+          # WhiteNoise serves from it, so this must run before gunicorn binds.
+          args:
+            - |
+              python manage.py collectstatic --noinput &&
+              exec gunicorn attendee.wsgi \
+                --bind 0.0.0.0:8000 \
+                --workers 3 \
+                --timeout 120 \
+                --access-logfile -
+          ports: [{containerPort: 8000, name: http}]
+          envFrom:
+            - configMapRef: {name: env}
+            - secretRef: {name: app-secrets}
+          # The Host header matters: ALLOWED_HOSTS does not include the pod IP, and kubelet
+          # sends the pod IP by default, which Django answers with 400 DisallowedHost.
+          # (A 301 from SECURE_SSL_REDIRECT is fine -- kubelet treats 2xx and 3xx as healthy.)
+          readinessProbe:
+            httpGet:
+              path: /health/
+              port: http
+              httpHeaders: [{name: Host, value: attendee.example.com}]
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /health/
+              port: http
+              httpHeaders: [{name: Host, value: attendee.example.com}]
+            initialDelaySeconds: 30
+            periodSeconds: 20
+            failureThreshold: 3
+          resources:
+            requests: {cpu: "250m", memory: "512Mi"}
+            limits: {cpu: "1", memory: "1Gi"}

--- a/k8s/31-deployment-worker.yaml
+++ b/k8s/31-deployment-worker.yaml
@@ -1,0 +1,38 @@
+# Celery workers.
+#
+# With LAUNCH_BOT_METHOD=kubernetes these workers do NOT run bots -- each bot gets its own pod.
+# They handle the surrounding jobs: webhook delivery, utterance/transcription processing,
+# calendar sync, and launching scheduled bots. So they are small and scale horizontally.
+#
+# The default ENTRYPOINT is kept here (no `command` override) exactly as the upstream dev
+# compose does, so the container is still correct if you ever fall back to LAUNCH_BOT_METHOD
+# unset, where bots run inside this process and need PulseAudio.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: attendee-worker
+  namespace: attendee
+  labels: {app.kubernetes.io/name: attendee, app.kubernetes.io/component: worker}
+spec:
+  replicas: 2
+  selector:
+    matchLabels: {app.kubernetes.io/name: attendee, app.kubernetes.io/component: worker}
+  template:
+    metadata:
+      labels: {app.kubernetes.io/name: attendee, app.kubernetes.io/component: worker}
+    spec:
+      serviceAccountName: attendee-app
+      imagePullSecrets: [{name: regcred}]
+      # Celery is configured with task_acks_late + reject_on_worker_lost, so an in-flight task
+      # is redelivered rather than lost. Give it room to finish first.
+      terminationGracePeriodSeconds: 120
+      containers:
+        - name: worker
+          image: REPLACE_WITH_REGISTRY/attendee:REPLACE_WITH_IMAGE_TAG
+          args: ["celery", "-A", "attendee", "worker", "-l", "INFO", "--concurrency", "4"]
+          envFrom:
+            - configMapRef: {name: env}
+            - secretRef: {name: app-secrets}
+          resources:
+            requests: {cpu: "500m", memory: "1Gi"}
+            limits: {cpu: "2", memory: "2Gi"}

--- a/k8s/32-deployment-scheduler.yaml
+++ b/k8s/32-deployment-scheduler.yaml
@@ -1,0 +1,82 @@
+# Singleton pollers. Both loop forever inside one process, so they are Deployments rather than
+# CronJobs -- and both MUST stay at replicas: 1. Two schedulers would double-launch scheduled
+# bots. `strategy: Recreate` guarantees the old pod is gone before the new one starts, which
+# RollingUpdate would not.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: attendee-scheduler
+  namespace: attendee
+  labels: {app.kubernetes.io/name: attendee, app.kubernetes.io/component: scheduler}
+spec:
+  replicas: 1
+  strategy: {type: Recreate}
+  selector:
+    matchLabels: {app.kubernetes.io/name: attendee, app.kubernetes.io/component: scheduler}
+  template:
+    metadata:
+      labels: {app.kubernetes.io/name: attendee, app.kubernetes.io/component: scheduler}
+    spec:
+      serviceAccountName: attendee-app
+      imagePullSecrets: [{name: regcred}]
+      terminationGracePeriodSeconds: 90
+      containers:
+        - name: scheduler
+          image: REPLACE_WITH_REGISTRY/attendee:REPLACE_WITH_IMAGE_TAG
+          command: ["/tini", "--"]
+          args: ["python", "manage.py", "run_scheduler"]
+          envFrom:
+            - configMapRef: {name: env}
+            - secretRef: {name: app-secrets}
+          # run_scheduler rewrites SCHEDULER_HEARTBEAT_FILE with a unix timestamp every cycle
+          # (60s by default). A stalled loop leaves the process alive but the file stale, which
+          # an httpGet or process check would never notice -- hence reading the timestamp.
+          livenessProbe:
+            exec:
+              command:
+                - python
+                - -c
+                - |
+                  import os, sys, time
+                  path = os.environ["SCHEDULER_HEARTBEAT_FILE"]
+                  with open(path) as f:
+                      written_at = float(f.read())
+                  sys.exit(0 if time.time() - written_at < 300 else 1)
+            initialDelaySeconds: 60
+            periodSeconds: 60
+            failureThreshold: 3
+          resources:
+            requests: {cpu: "100m", memory: "256Mi"}
+            limits: {cpu: "500m", memory: "512Mi"}
+---
+# Detects bots whose pod never came up (ImagePullBackOff, unschedulable, evicted) and records
+# the failure against the bot so it does not hang in "launching" forever. Kubernetes-mode only.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: attendee-correct-failed-bot-launches
+  namespace: attendee
+  labels: {app.kubernetes.io/name: attendee, app.kubernetes.io/component: correct-failed-bot-launches}
+spec:
+  replicas: 1
+  strategy: {type: Recreate}
+  selector:
+    matchLabels: {app.kubernetes.io/name: attendee, app.kubernetes.io/component: correct-failed-bot-launches}
+  template:
+    metadata:
+      labels: {app.kubernetes.io/name: attendee, app.kubernetes.io/component: correct-failed-bot-launches}
+    spec:
+      serviceAccountName: attendee-app
+      imagePullSecrets: [{name: regcred}]
+      terminationGracePeriodSeconds: 60
+      containers:
+        - name: correct-failed-bot-launches
+          image: REPLACE_WITH_REGISTRY/attendee:REPLACE_WITH_IMAGE_TAG
+          command: ["/tini", "--"]
+          args: ["python", "manage.py", "run_correct_failed_bot_launches", "--interval", "60"]
+          envFrom:
+            - configMapRef: {name: env}
+            - secretRef: {name: app-secrets}
+          resources:
+            requests: {cpu: "100m", memory: "256Mi"}
+            limits: {cpu: "500m", memory: "512Mi"}

--- a/k8s/40-service.yaml
+++ b/k8s/40-service.yaml
@@ -1,0 +1,15 @@
+# In-cluster address for the web app. Bot pods reach it through INTERNAL_SITE_DOMAIN
+# (attendee-web.attendee.svc.cluster.local:8000), which keeps their callbacks off the public
+# ingress entirely.
+apiVersion: v1
+kind: Service
+metadata:
+  name: attendee-web
+  namespace: attendee
+spec:
+  type: ClusterIP
+  selector: {app.kubernetes.io/name: attendee, app.kubernetes.io/component: web}
+  ports:
+    - name: http
+      port: 8000
+      targetPort: http

--- a/k8s/41-ingress.yaml
+++ b/k8s/41-ingress.yaml
@@ -1,0 +1,31 @@
+# TLS termination. Adapt the ingressClassName and annotations to whatever the cluster runs --
+# this example assumes ingress-nginx plus cert-manager.
+#
+# Two requirements, whatever the controller:
+#   1. It must forward X-Forwarded-Proto. Django's SECURE_PROXY_SSL_HEADER relies on it; without
+#      it every request looks insecure and SECURE_SSL_REDIRECT sends clients into a redirect loop.
+#   2. proxy-body-size must be generous. Bots upload recordings through the app.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: attendee
+  namespace: attendee
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    nginx.ingress.kubernetes.io/proxy-body-size: "512m"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "300"
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts: [attendee.example.com]
+      secretName: attendee-tls
+  rules:
+    - host: attendee.example.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: attendee-web
+                port: {name: http}

--- a/k8s/50-job-migrate.yaml
+++ b/k8s/50-job-migrate.yaml
@@ -1,0 +1,29 @@
+# Run once per release, BEFORE rolling the deployments. Job names are immutable, so either
+# delete the old Job first or template the name with the release tag.
+#
+#   kubectl -n attendee delete job attendee-migrate --ignore-not-found
+#   kubectl -n attendee apply -f k8s/50-job-migrate.yaml
+#   kubectl -n attendee wait --for=condition=complete job/attendee-migrate --timeout=10m
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: attendee-migrate
+  namespace: attendee
+spec:
+  backoffLimit: 2
+  template:
+    spec:
+      restartPolicy: Never
+      serviceAccountName: attendee-app
+      imagePullSecrets: [{name: regcred}]
+      containers:
+        - name: migrate
+          image: REPLACE_WITH_REGISTRY/attendee:REPLACE_WITH_IMAGE_TAG
+          command: ["/tini", "--"]
+          args: ["python", "manage.py", "migrate", "--noinput"]
+          envFrom:
+            - configMapRef: {name: env}
+            - secretRef: {name: app-secrets}
+          resources:
+            requests: {cpu: "100m", memory: "256Mi"}
+            limits: {cpu: "1", memory: "1Gi"}

--- a/k8s/60-cronjobs.yaml
+++ b/k8s/60-cronjobs.yaml
@@ -1,0 +1,97 @@
+# Housekeeping. The first two are required in Kubernetes mode -- without them, finished bot
+# pods accumulate forever and a bot whose pod dies mid-meeting is never marked failed.
+# The data-retention job at the bottom is optional; set it to your retention policy.
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: attendee-clean-up-completed-bot-pods
+  namespace: attendee
+spec:
+  schedule: "*/5 * * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      template:
+        spec:
+          restartPolicy: Never
+          serviceAccountName: attendee-app
+          imagePullSecrets: [{name: regcred}]
+          containers:
+            - name: cleanup
+              image: REPLACE_WITH_REGISTRY/attendee:REPLACE_WITH_IMAGE_TAG
+              command: ["/tini", "--"]
+              args: ["python", "manage.py", "clean_up_completed_bot_pods"]
+              envFrom:
+                - configMapRef: {name: env}
+                - secretRef: {name: app-secrets}
+              resources:
+                requests: {cpu: "50m", memory: "192Mi"}
+                limits: {cpu: "500m", memory: "512Mi"}
+---
+# Kills pods for bots that stopped sending heartbeats (crashed mid-meeting) or never launched,
+# and records the reason -- reading the pod's status and events, which is why the app's Role
+# needs `events: list`.
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: attendee-clean-up-stalled-bots
+  namespace: attendee
+spec:
+  schedule: "*/5 * * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      template:
+        spec:
+          restartPolicy: Never
+          serviceAccountName: attendee-app
+          imagePullSecrets: [{name: regcred}]
+          containers:
+            - name: cleanup
+              image: REPLACE_WITH_REGISTRY/attendee:REPLACE_WITH_IMAGE_TAG
+              command: ["/tini", "--"]
+              args: ["python", "manage.py", "clean_up_bots_with_heartbeat_timeout_or_that_never_launched"]
+              envFrom:
+                - configMapRef: {name: env}
+                - secretRef: {name: app-secrets}
+              resources:
+                requests: {cpu: "50m", memory: "192Mi"}
+                limits: {cpu: "500m", memory: "512Mi"}
+---
+# OPTIONAL data retention. --days is the retention window; recordings and transcripts older
+# than it are deleted. Remove this CronJob if you retain data indefinitely.
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: attendee-cleanup-old-data
+  namespace: attendee
+spec:
+  schedule: "30 3 * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      template:
+        spec:
+          restartPolicy: Never
+          serviceAccountName: attendee-app
+          imagePullSecrets: [{name: regcred}]
+          containers:
+            - name: cleanup
+              image: REPLACE_WITH_REGISTRY/attendee:REPLACE_WITH_IMAGE_TAG
+              command: ["/tini", "--"]
+              args: ["python", "manage.py", "cleanup_old_data", "--days", "90"]
+              envFrom:
+                - configMapRef: {name: env}
+                - secretRef: {name: app-secrets}
+              resources:
+                requests: {cpu: "100m", memory: "256Mi"}
+                limits: {cpu: "1", memory: "1Gi"}

--- a/k8s/kustomization.yaml
+++ b/k8s/kustomization.yaml
@@ -1,0 +1,26 @@
+# Convenience wrapper so the image tag is set in one place.
+#
+# ⚠ newTag below and CUBER_RELEASE_VERSION in 20-configmap-env.yaml must be the SAME value.
+# Kustomize rewrites container images; it does not touch ConfigMap values, and the app builds
+# each bot pod's image as "$BOT_POD_IMAGE:$CUBER_RELEASE_VERSION". If they drift, the app and
+# its bots run different builds.
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - 00-namespaces.yaml
+  - 10-rbac.yaml
+  - 20-configmap-env.yaml
+  - 21-secret-app-secrets.yaml   # remove if the Secret is managed outside git
+  - 30-deployment-web.yaml
+  - 31-deployment-worker.yaml
+  - 32-deployment-scheduler.yaml
+  - 40-service.yaml
+  - 41-ingress.yaml
+  - 60-cronjobs.yaml
+  # 50-job-migrate.yaml is applied on its own, before the rollout -- not part of the base.
+
+images:
+  - name: REPLACE_WITH_REGISTRY/attendee
+    newName: REPLACE_WITH_REGISTRY/attendee
+    newTag: REPLACE_WITH_IMAGE_TAG

--- a/prod.docker-compose.yaml
+++ b/prod.docker-compose.yaml
@@ -1,0 +1,56 @@
+# Production Attendee WITHOUT Kubernetes -- bots run inside the Celery workers.
+#
+# Postgres, Redis and object storage are external; nothing stateful is defined here. All
+# configuration comes from .env (start from .env.production.example).
+#
+#   docker compose -f prod.docker-compose.yaml run --rm attendee-web python manage.py migrate
+#   docker compose -f prod.docker-compose.yaml up -d
+#
+# Read the sizing note in DEPLOYMENT.md before choosing --concurrency: each concurrent bot is a
+# full Chrome plus PulseAudio, roughly 4 vCPU and 4 GB while it is in a meeting.
+
+x-attendee-base: &attendee-base
+  image: ${ATTENDEE_IMAGE:?set ATTENDEE_IMAGE, e.g. registry.example.com/attendee:2026-09-10-1}
+  env_file:
+    - .env
+  restart: unless-stopped
+  logging:
+    driver: json-file
+    options: {max-size: "50m", max-file: "5"}
+
+services:
+  attendee-web:
+    <<: *attendee-base
+    # /tini stays PID 1 for signal handling; entrypoint.sh (PulseAudio) is skipped because the
+    # web process never runs a bot.
+    entrypoint: ["/tini", "--", "sh", "-c"]
+    command:
+      - >
+        python manage.py collectstatic --noinput &&
+        exec gunicorn attendee.wsgi --bind 0.0.0.0:8000 --workers 3 --timeout 120 --access-logfile -
+    ports:
+      - "8000:8000"
+    healthcheck:
+      # ALLOWED_HOSTS will not contain "localhost", so the Host header has to be set explicitly
+      # or Django answers 400 DisallowedHost. A 301 from SECURE_SSL_REDIRECT is expected and
+      # fine -- curl -f only fails on 4xx/5xx.
+      test: ["CMD-SHELL", "curl -fsS -o /dev/null -H \"Host: ${SITE_DOMAIN}\" http://127.0.0.1:8000/health/"]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 60s
+
+  # Bots run HERE. Keeps the image's default entrypoint so PulseAudio is available.
+  attendee-worker:
+    <<: *attendee-base
+    command: celery -A attendee worker -l INFO --concurrency ${CELERY_CONCURRENCY:-2}
+    # Celery uses acks_late + reject_on_worker_lost, so a task interrupted by a restart is
+    # redelivered. Still: restarting this container kills every bot currently in a meeting.
+    stop_grace_period: 120s
+    shm_size: 2gb  # Chrome crashes on the 64MB default
+
+  attendee-scheduler:
+    <<: *attendee-base
+    entrypoint: ["/tini", "--"]
+    command: python manage.py run_scheduler
+    stop_grace_period: 90s

--- a/selfhost.docker-compose.yaml
+++ b/selfhost.docker-compose.yaml
@@ -1,0 +1,135 @@
+# Local self-hosted Attendee, with rustfs standing in for S3.
+#
+# This is the upstream dev stack plus an S3-compatible object store, so nothing has to reach a
+# real cloud bucket to record a meeting. Production does NOT use this file -- see DEPLOYMENT.md.
+#
+#   docker compose -f selfhost.docker-compose.yaml build
+#   docker compose -f selfhost.docker-compose.yaml run --rm attendee-app python init_env.py >> .env
+#   docker compose -f selfhost.docker-compose.yaml up -d
+#   docker compose -f selfhost.docker-compose.yaml exec attendee-app python manage.py migrate
+#
+# Host ports are deliberately offset from Mawrid's compose stack, which already holds
+# 8000 (backend), 5432, 6379, 9000 and 9001 (its own rustfs). Both stacks can run at once.
+#   Attendee app     -> http://localhost:8100
+#   rustfs S3 API    -> http://localhost:9100
+#   rustfs console   -> http://localhost:9101
+
+x-attendee-base: &attendee-base
+  build: ./
+  volumes:
+    - .:/attendee
+  networks:
+    - attendee_network
+  env_file:
+    - .env
+  environment:
+    - DJANGO_SETTINGS_MODULE=attendee.settings.development
+    - POSTGRES_HOST=postgres
+    - REDIS_URL=redis://redis:6379/5
+  depends_on:
+    postgres:
+      condition: service_healthy
+    redis:
+      condition: service_started
+    rustfs-init:
+      condition: service_completed_successfully
+
+services:
+  attendee-app:
+    <<: *attendee-base
+    ports:
+      - "8100:8000"
+    # entrypoint.sh boots PulseAudio, which only bot processes need.
+    entrypoint: []
+    command: python manage.py runserver 0.0.0.0:8000
+
+  # Bots run inside this worker (LAUNCH_BOT_METHOD is unset locally), so it KEEPS the default
+  # entrypoint -- without PulseAudio a bot has no audio device and fails to join.
+  attendee-worker:
+    <<: *attendee-base
+    environment:
+      - DJANGO_SETTINGS_MODULE=attendee.settings.development
+      - POSTGRES_HOST=postgres
+      - REDIS_URL=redis://redis:6379/5
+      - ENABLE_CHROME_SANDBOX=false
+    command: celery -A attendee worker -l INFO
+
+  attendee-scheduler:
+    <<: *attendee-base
+    entrypoint: []
+    command: python manage.py run_scheduler
+
+  postgres:
+    image: postgres:15.3-alpine
+    environment:
+      POSTGRES_DB: attendee_development
+      POSTGRES_USER: attendee_development_user
+      POSTGRES_PASSWORD: attendee_development_user
+      PGDATA: /data/postgres
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U attendee_development_user -d attendee_development"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+    volumes:
+      - postgres:/data/postgres
+    networks:
+      - attendee_network
+    restart: unless-stopped
+
+  redis:
+    image: redis:7-alpine
+    networks:
+      - attendee_network
+    restart: unless-stopped
+    volumes:
+      - redis:/data/redis
+
+  # S3-compatible object storage, written in Rust (a MinIO alternative). Attendee reaches it
+  # over the compose network at http://rustfs:9000 -- that is AWS_ENDPOINT_URL in .env.
+  rustfs:
+    image: rustfs/rustfs:latest
+    networks:
+      - attendee_network
+    ports:
+      - "9100:9000"  # S3 API
+      - "9101:9001"  # Web console
+    environment:
+      # Boot rustfs with the same credentials Attendee uses, so they always match.
+      - RUSTFS_ACCESS_KEY=${AWS_ACCESS_KEY_ID:-attendeeadmin}
+      - RUSTFS_SECRET_KEY=${AWS_SECRET_ACCESS_KEY:-attendeeadmin}
+      - RUSTFS_VOLUMES=/data
+      - RUSTFS_CONSOLE_ENABLE=true
+    volumes:
+      - rustfs-data:/data
+
+  # One-shot init: wait for rustfs, then create the recording bucket. Attendee never creates its
+  # own bucket, so without this every upload fails with NoSuchBucket. `mb` on an existing bucket
+  # errors harmlessly -- commands are ';'-separated and the trailing echo makes the container
+  # exit 0, so a restart against the persisted volume still satisfies
+  # service_completed_successfully for the app containers.
+  rustfs-init:
+    image: rustfs/rc:latest
+    depends_on:
+      - rustfs
+    networks:
+      - attendee_network
+    environment:
+      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-attendeeadmin}
+      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-attendeeadmin}
+      - AWS_RECORDING_STORAGE_BUCKET_NAME=${AWS_RECORDING_STORAGE_BUCKET_NAME:-attendee}
+    entrypoint: >
+      /bin/sh -c "
+      until rc alias set rustfs http://rustfs:9000 $${AWS_ACCESS_KEY_ID} $${AWS_SECRET_ACCESS_KEY}; do echo 'waiting for rustfs...'; sleep 2; done;
+      rc mb rustfs/$${AWS_RECORDING_STORAGE_BUCKET_NAME};
+      echo 'rustfs bucket ready';
+      "
+
+networks:
+  attendee_network:
+    driver: bridge
+
+volumes:
+  postgres:
+  redis:
+  rustfs-data:


### PR DESCRIPTION
Adds what is needed to run Attendee outside Attendee Cloud, against externally managed Postgres, Redis and S3-compatible object storage.

- DEPLOYMENT.md: operator handover covering both deployment shapes, with a full environment variable reference and a troubleshooting table.
- k8s/: manifests for the Kubernetes path. RBAC is scoped to exactly the API calls the app makes (pods create/get/list/delete, events list, and services create in the streamer namespace), and the pod-cleanup CronJobs the mode depends on are included.
- prod.docker-compose.yaml: the Celery path, where bots run in the worker.
- selfhost.docker-compose.yaml: local stack with rustfs standing in for S3, so nothing has to reach a real bucket to record a meeting.
- .env.production.example / .env.selfhost.example: annotated templates.

Fix S3 compatibility for non-AWS endpoints. The two raw boto3 clients that upload bot media passed no botocore Config, so against an S3-compatible endpoint botocore folded the bucket into the hostname and negotiated SigV2, which those servers reject with SignatureDoesNotMatch. s3_client_config centralises path addressing and s3v4 for both, and settings now default AWS_S3_ADDRESSING_STYLE to path whenever AWS_ENDPOINT_URL is set. Behaviour against real AWS S3 is unchanged.

Also make the development SITE_DOMAIN env-driven, so the app can be published on a port other than 8000 without the account confirmation links pointing at the wrong one.