### PR TITLE
fix: only kill worker process group on shutdown when bots run in the celery worker

### DIFF
--- a/attendee/settings/base.py
+++ b/attendee/settings/base.py
@@ -203,7 +203,12 @@ CELERY_TASK_ROUTES = {
     },
 }
 
-if os.getenv("LAUNCH_BOT_METHOD") != "kubernetes" and os.getenv("LAUNCH_BOT_METHOD") != "docker-compose-multi-host":
+# With the kubernetes and docker-compose-multi-host launch methods, bots run in a separate pod/container
+# via `python manage.py run_bot` and the Celery worker only runs short scheduling, webhook and transcription
+# tasks. Otherwise (unset or "celery") the run_bot task itself executes inside the worker.
+BOTS_RUN_IN_CELERY_WORKER = os.getenv("LAUNCH_BOT_METHOD") not in ("kubernetes", "docker-compose-multi-host")
+
+if BOTS_RUN_IN_CELERY_WORKER:
     # This setting means that each celery worker process will be recreated after each task.
     # Needed because latest Zoom SDK has segfault issue unless we recreate the process after each bot.
     CELERY_WORKER_MAX_TASKS_PER_CHILD = 1

--- a/bots/tasks/run_bot_task.py
+++ b/bots/tasks/run_bot_task.py
@@ -4,6 +4,7 @@ import signal
 
 from celery import shared_task
 from celery.signals import worker_shutting_down
+from django.conf import settings
 
 from bots.bot_controller import BotController
 
@@ -28,10 +29,21 @@ def kill_child_processes():
         pass  # Process group may no longer exist
 
 
-@worker_shutting_down.connect
 def shutting_down_handler(sig, how, exitcode, **kwargs):
-    # Just adding this code so we can see how to shut down all the tasks
-    # when the main process is terminated.
-    # It's likely overkill.
+    # When bots run inside the worker (LAUNCH_BOT_METHOD unset or "celery"), a bot task
+    # spawns Chrome and other subprocesses that must not outlive the worker, so we
+    # SIGTERM the whole process group as soon as the worker starts shutting down.
     logger.info("Celery worker shutting down, sending SIGTERM to all child processes")
     kill_child_processes()
+
+
+# Only connect the handler when bots run in-process. Celery's response to SIGTERM is a
+# warm shutdown: stop consuming and let in-flight tasks finish before exiting. This
+# handler fires at the start of that warm shutdown and SIGTERMs every prefork child,
+# so busy children die with WorkerLostError and their tasks are abandoned (and, with
+# acks_late, requeued and re-run elsewhere). With the kubernetes and
+# docker-compose-multi-host launch methods, run_bot never executes in the worker, so
+# there are no bot subprocesses to clean up and the warm shutdown should be honoured
+# so the pod's termination grace period is actually used.
+if settings.BOTS_RUN_IN_CELERY_WORKER:
+    worker_shutting_down.connect(shutting_down_handler)

--- a/bots/tests/test_run_bot_task_shutdown.py
+++ b/bots/tests/test_run_bot_task_shutdown.py
@@ -1,0 +1,38 @@
+import importlib
+from unittest.mock import patch
+
+from celery.signals import worker_shutting_down
+from django.conf import settings
+from django.test import SimpleTestCase, override_settings
+
+from bots.tasks import run_bot_task
+
+
+def _handler_is_connected():
+    return any(receiver() is run_bot_task.shutting_down_handler for _, receiver in worker_shutting_down.receivers if callable(receiver))
+
+
+class WorkerShuttingDownHandlerConnectionTest(SimpleTestCase):
+    """The handler is connected at import time, so reload the module under each setting value."""
+
+    def _reload_with_setting(self, bots_run_in_celery_worker):
+        worker_shutting_down.disconnect(run_bot_task.shutting_down_handler)
+        with override_settings(BOTS_RUN_IN_CELERY_WORKER=bots_run_in_celery_worker):
+            importlib.reload(run_bot_task)
+
+    def tearDown(self):
+        # Restore the module to the state matching the real settings so other tests are unaffected.
+        self._reload_with_setting(settings.BOTS_RUN_IN_CELERY_WORKER)
+
+    def test_handler_not_connected_when_bots_run_outside_worker(self):
+        self._reload_with_setting(False)
+        self.assertFalse(_handler_is_connected())
+
+    def test_handler_connected_when_bots_run_in_worker(self):
+        self._reload_with_setting(True)
+        self.assertTrue(_handler_is_connected())
+
+    def test_handler_calls_kill_child_processes(self):
+        with patch.object(run_bot_task, "kill_child_processes") as mock_kill:
+            run_bot_task.shutting_down_handler(sig="SIGTERM", how="Warm", exitcode=0)
+        mock_kill.assert_called_once_with()


### PR DESCRIPTION
## Problem

`bots/tasks/run_bot_task.py` connects a `worker_shutting_down` handler that SIGTERMs the worker's whole process group. Celery's response to SIGTERM is a warm shutdown (stop consuming, finish in-flight tasks), but this handler fires at the start of it and kills every prefork child immediately. Busy children die with `WorkerLostError`, and with `acks_late` their tasks are requeued and re-run on another worker. On Kubernetes the pod's `terminationGracePeriodSeconds` is never used.

For `process_utterance_group_for_async_transcription` this means the AssemblyAI job is submitted twice and the original transcript is left orphaned at AssemblyAI. We see this several times a day on node consolidation.

The handler only makes sense when bots run inside the worker (`LAUNCH_BOT_METHOD` unset or `celery`), where a bot task spawns Chrome and other subprocesses that must not outlive the worker. With `kubernetes` and `docker-compose-multi-host`, `run_bot` never executes in the worker.

## Change

- Add `BOTS_RUN_IN_CELERY_WORKER` setting, computed from the same `LAUNCH_BOT_METHOD` check already used for `CELERY_WORKER_MAX_TASKS_PER_CHILD`.
- Only connect the `worker_shutting_down` handler when that setting is true. Behaviour is unchanged for in-process bot mode; `kill_child_processes` is untouched.
- No changes to `acks_late`, prefetch or `reject_on_worker_lost`.

## Verification

- New tests reload the task module under `override_settings` and assert the receiver is connected only when `BOTS_RUN_IN_CELERY_WORKER` is true.
- Ran in the worker image with `LAUNCH_BOT_METHOD=kubernetes` and `celery`: receiver absent / present respectively, `CELERY_WORKER_MAX_TASKS_PER_CHILD` unchanged.
- No other code references `worker_shutting_down`, `killpg` or `kill_child_processes`.